### PR TITLE
Add host_network: true for use in home assistant

### DIFF
--- a/home_assistant/config.yml
+++ b/home_assistant/config.yml
@@ -13,6 +13,7 @@ startup: application
 boot: auto
 apparmor: false
 hassio_api: true
+host_network: true
 ports:
   1935/tcp: 1935
   8554/tcp: 8554

--- a/home_assistant/dev/config.yml
+++ b/home_assistant/dev/config.yml
@@ -12,6 +12,7 @@ startup: application
 boot: auto
 apparmor: false
 hassio_api: true
+host_network: true
 ports:
   1935/tcp: 1935
   8554/tcp: 8554

--- a/home_assistant/edge/config.yml
+++ b/home_assistant/edge/config.yml
@@ -12,6 +12,7 @@ startup: application
 boot: auto
 apparmor: false
 hassio_api: true
+host_network: true
 ports:
   1935/tcp: 1935
   8554/tcp: 8554

--- a/home_assistant/hw/config.yml
+++ b/home_assistant/hw/config.yml
@@ -10,6 +10,7 @@ startup: application
 boot: auto
 apparmor: false
 hassio_api: true
+host_network: true
 ports:
   1935/tcp: 1935
   8554/tcp: 8554

--- a/home_assistant/previous/config.yml
+++ b/home_assistant/previous/config.yml
@@ -13,6 +13,7 @@ startup: application
 boot: auto
 apparmor: false
 hassio_api: true
+host_network: true
 ports:
   1935/tcp: 1935
   8554/tcp: 8554


### PR DESCRIPTION
Docker changes something, so this addon must run on the host network for some cameras

Fixes: https://github.com/mrlt8/docker-wyze-bridge/issues/1438 https://github.com/mrlt8/docker-wyze-bridge/issues/1433 https://github.com/mrlt8/docker-wyze-bridge/issues/1434