### PR TITLE
Add formatting of {cam_name} and {img} to webhooks.py

### DIFF
--- a/app/wyzebridge/webhooks.py
+++ b/app/wyzebridge/webhooks.py
@@ -10,6 +10,8 @@ def send_webhook(event: str, camera: str, msg: str, img: Optional[str] = None) -
     if not (url := env_cam(f"{event}_webhooks", camera, style="original")):
         return
 
+    url = url.format(cam_name=camera, img=str(img))
+
     header = {
         "user-agent": f"wyzebridge/{VERSION}",
         "X-Title": f"{event} event".title(),


### PR DESCRIPTION
See https://github.com/mrlt8/docker-wyze-bridge/issues/1378 formatting of {params} in webhooks URLs have been missing since 2.9.x. This patch adds it back to send_webhooks