### PR TITLE
Clean up some logging

### DIFF
--- a/app/wyzebridge/hass.py
+++ b/app/wyzebridge/hass.py
@@ -26,8 +26,8 @@ def setup_hass(hass_token: Optional[str]) -> None:
         for i in net_info["data"]["interfaces"]:
             if i["primary"]:
                 environ["WB_IP"] = i["ipv4"]["address"][0].split("/")[0]
-    except Exception as e:
-        logger.error(f"WEBRTC SETUP: {e}")
+    except Exception as ex:
+        logger.error(f"WEBRTC SETUP: [{type(ex).__name__}] {ex}")
 
     mqtt_conf = requests.get("http://supervisor/services/mqtt", headers=auth).json()
     if "ok" in mqtt_conf.get("result") and (data := mqtt_conf.get("data")):

--- a/app/wyzebridge/mqtt.py
+++ b/app/wyzebridge/mqtt.py
@@ -31,9 +31,9 @@ def mqtt_enabled(func):
             try:
                 return func(*args, **kwargs)
             except (ConnectionRefusedError, TimeoutError, gaierror) as ex:
-                logger.error(f"[MQTT] {ex}. Retrying {retry}/{RETRIES}...")
+                logger.error(f"[MQTT]  [{type(ex).__name__}] {ex}. Retrying {retry}/{RETRIES}...")
             except Exception as ex:
-                logger.error(f"[MQTT] {ex}")
+                logger.error(f"[MQTT] [{type(ex).__name__}] {ex}")
             sleep(1)
 
         logger.error(f"[MQTT] {RETRIES}/{RETRIES} retries failed. Disabling MQTT.")

--- a/app/wyzebridge/mtx_server.py
+++ b/app/wyzebridge/mtx_server.py
@@ -148,7 +148,10 @@ class MtxServer:
         if self.sub_process:
             return
         logger.info(f"[MTX] starting MediaMTX {getenv('MTX_TAG')}")
-        self.sub_process = Popen(["/app/mediamtx", "/app/mediamtx.yml"])
+        self.sub_process = Popen(["./mediamtx", "./mediamtx.yml"],
+                                 stdout=None,  # None means inherit from parent process
+                                 stderr=None   # None means inherit from parent process
+        )
 
     def stop(self):
         if not self.sub_process:
@@ -214,8 +217,8 @@ def generate_certificates(cert_path):
         logger.info("[MTX] 🔐 Generating key for LL-HLS")
         Popen(
             ["openssl", "genrsa", "-out", f"{cert_path}.key", "2048"],
-            stdout=DEVNULL,
-            stderr=DEVNULL,
+            stdout=None,  # None means inherit from parent process
+            stderr=None   # None means inherit from parent process
         ).wait()
     if not Path(f"{cert_path}.crt").is_file():
         logger.info("[MTX] 🔏 Generating certificate for LL-HLS")
@@ -227,8 +230,8 @@ def generate_certificates(cert_path):
             + (["-addext", f"subjectAltName = DNS:{dns}"] if dns else [])
             + ["-out", f"{cert_path}.crt"]
             + ["-days", "3650"],
-            stdout=DEVNULL,
-            stderr=DEVNULL,
+            stdout=None,  # None means inherit from parent process
+            stderr=None   # None means inherit from parent process
         ).wait()
 
 

--- a/app/wyzebridge/stream.py
+++ b/app/wyzebridge/stream.py
@@ -215,7 +215,7 @@ class StreamManager:
         except TimeoutExpired:
             logger.error(f"[{cam_name}] Snapshot timed out")
         except Exception as ex:
-            logger.error(ex)
+            logger.error(f"[{cam_name}] [{type(ex).__name__}] {ex}")
         stop_subprocess(ffmpeg)
 
         return False

--- a/app/wyzebridge/webhooks.py
+++ b/app/wyzebridge/webhooks.py
@@ -26,4 +26,4 @@ def send_webhook(event: str, camera: str, msg: str, img: Optional[str] = None) -
         resp = requests.post(url, headers=header, data=msg, verify=False)
         resp.raise_for_status()
     except Exception as ex:
-        print(f"[WEBHOOKS] {ex}")
+        print(f"[WEBHOOKS] [{type(ex).__name__}] {ex}")

--- a/app/wyzebridge/wyze_control.py
+++ b/app/wyzebridge/wyze_control.py
@@ -53,7 +53,7 @@ def pull_last_image(cam: dict, path: str, as_snap: bool = False):
                 with open(f"{cam['img_dir']}{cam['uri']}{save_name}", "wb") as img:
                     img.write(resp.content)
     except requests.exceptions.ConnectionError as ex:
-        logger.error(ex)
+        logger.error(f"[IMAGE] Error: [{type(ex).__name__}] {ex}")
     finally:
         cam["last_photo"] = file_name, modded
 
@@ -393,7 +393,7 @@ def motion_alarm(cam: dict):
             resp = requests.get(http.format(cam_name=cam["uri"]))
             resp.raise_for_status()
         except requests.exceptions.HTTPError as ex:
-            logger.error(ex)
+            logger.error(f"[CONTROL] Error: [{type(ex).__name__}] {ex}")
 
 
 def parse_fw(fw_ver: str) -> tuple[str, tuple[int, ...]]:

--- a/app/wyzebridge/wyze_stream.py
+++ b/app/wyzebridge/wyze_stream.py
@@ -450,16 +450,16 @@ def start_tutk_stream(uri: str, stream: StreamTuple, queue: QueueTuple, state: c
         if ex.code in {-10, -13, -19, -68, -90}:
             exit_code = ex.code
     except ValueError as ex:
-        logger.warning(ex)
+        logger.warning(f"[TUTK] Error: [{type(ex).__name__}] {ex}")
         if ex.args[0] == "ENR_AUTH_FAILED":
             logger.warning("⏰ Expired ENR?")
             exit_code = -19
     except BrokenPipeError:
-        logger.info("FFMPEG stopped")
+        logger.info("[TUTK] FFMPEG stopped")
     except Exception as ex:
-        logger.warning(f"[{type(ex).__name__}] {ex}")
+        logger.warning(f"[TUTK] Exception: [{type(ex).__name__}] {ex}")
     else:
-        logger.warning("Stream stopped")
+        logger.warning("[TUTK] Stream stopped")
     finally:
         state.value = exit_code
         stop_and_wait(audio_thread)
@@ -536,7 +536,7 @@ def get_camera_info(sess: WyzeIOTCSession) -> tuple[str, str]:
 def get_video_params(sess: WyzeIOTCSession) -> tuple[str, int]:
     cam_info = sess.camera.camera_info
     if not cam_info or not (video_param := cam_info.get("videoParm")):
-        logger.warn("⚠️ camera_info is missing videoParm. Using default values.")
+        logger.warning("⚠️ camera_info is missing videoParm. Using default values.")
         video_param = {"type": "h264", "fps": 20}
 
     fps = int(video_param.get("fps", 0))

--- a/home_assistant/config.yml
+++ b/home_assistant/config.yml
@@ -3,7 +3,7 @@ description: WebRTC/RTSP/RTMP/LL-HLS bridge for Wyze cams in a docker container
 slug: docker_wyze_bridge
 url: https://github.com/idisposable/docker-wyze-bridge
 image: idisposablegithub365/wyze-bridge
-version: 3.0.6
+version: 3.0.7-beta1
 stage: stable
 arch:
   - armv7


### PR DESCRIPTION
Follow [FUNCTIONNAME] pattern
Allow MediaMTX and openssl messages to trickle up into main stdout and stderr
Emit exception type name
Use logger.warning (not warnings.warn)
