### PR TITLE
Add exception handling to ffmpeg pruning logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ See [basic usage](#basic-usage) for additional information or visit the [wiki pa
   of *either* a `"%s"` or **all** of of "%Y", "%m", "%d", "%H", "%M", "%S" (case-sensitive).
   If the value is not compliant, to keep MediaMTX from erroring out, we append `"_%s"` whatever 
   was specified and emit a warning.
-- Changed the default `RECORD_PATH` to `"record/%path/%Y/%m/%d/"`
+- Changed the default `RECORD_PATH` to `"record/{cam_name}/%Y/%m/%d/"`
 - Changed the default `RECORD_FILE_NAME` to `"%Y-%m-%d-%H-%M-%S"`
 
 ## What's Changed in v3.10.1
@@ -197,8 +197,8 @@ Recoding streams has been updated to use MediaMTX with the option to delete olde
 
 Use `RECORD_ALL` or `RECORD_CAM_NAME` to enable recording.
 
-- `RECORD_FILE_NAME` Available variables are `%path` or `{cam_name}`, `%Y` `%m` `%d` `%H` `%M` `%S` `%f` `%s` (time in strftime format).
-- `RECORD_PATH` Available variables are `%path` or `{cam_name}`, `%Y` `%m` `%d` `%H` `%M` `%S` `%f` `%s` (time in strftime format).
+- `RECORD_FILE_NAME` Available variables are `{CAM_NAME}` or `{cam_name}`, `%Y` `%m` `%d` `%H` `%M` `%S` `%f` `%s` (time in strftime format).
+- `RECORD_PATH` Available variables are `{CAM_NAME}` or `{cam_name}`, `%Y` `%m` `%d` `%H` `%M` `%S` `%f` `%s` (time in strftime format).
 - `RECORD_LENGTH` Length of each clip. Use `s` for seconds , `h` for hours. Defaults to `60s`
 - `RECORD_KEEP` Delete older clips. Use `s` for seconds , `h` for hours. Set to 0s to disable automatic deletion. Defaults to `0s`
 

--- a/app/wyzebridge/ffmpeg.py
+++ b/app/wyzebridge/ffmpeg.py
@@ -159,7 +159,7 @@ def re_encode_video(uri: str, is_vertical: bool) -> list[str]:
 
 
 def get_livestream_cmd(uri: str) -> str:
-    flv = "|[f=flv:flvflags=no_duration_filesize:use_fifo=1:fifo_options=attempt_recovery=1:drop_pkts_on_overflow=1:onfail=abort]"
+    flv = r"|[f=flv:flvflags=no_duration_filesize:use_fifo=1:fifo_options=attempt_recovery=1\\\:drop_pkts_on_overflow=1:onfail=abort]"
 
     for platform, api in LIVESTREAM_PLATFORMS.items():
         key = env_bool(f"{platform}_{uri}", style="original")

--- a/app/wyzebridge/mtx_server.py
+++ b/app/wyzebridge/mtx_server.py
@@ -13,7 +13,7 @@ MTX_CONFIG = "/app/mediamtx.yml"
 RECORD_LENGTH = env_bool("RECORD_LENGTH", "60s")
 RECORD_KEEP = env_bool("RECORD_KEEP", "0s")
 REC_FILE = env_bool("RECORD_FILE_NAME", "%Y-%m-%d-%H-%M-%S", style="original").strip("/")
-REC_PATH = env_bool("RECORD_PATH", "record/%path/%Y/%m/%d/", style="original")
+REC_PATH = env_bool("RECORD_PATH", "record/{cam_name}/%Y/%m/%d/", style="original")
 RECORD_PATH = f"{Path('/') / Path(REC_PATH) / Path(REC_FILE)}".removesuffix(".mp4")
 
 class MtxInterface:

--- a/home_assistant/CHANGELOG.md
+++ b/home_assistant/CHANGELOG.md
@@ -23,7 +23,7 @@
   of *either* a `"%s"` or **all** of of "%Y", "%m", "%d", "%H", "%M", "%S" (case-sensitive).
   If the value is not compliant, to keep MediaMTX from erroring out, we append `"_%s"` whatever 
   was specified and emit a warning.
-- Changed the default `RECORD_PATH` to `"record/%path/%Y/%m/%d/"`
+- Changed the default `RECORD_PATH` to `"record/{cam_name}/%Y/%m/%d/"`
 - Changed the default `RECORD_FILE_NAME` to `"%Y-%m-%d-%H-%M-%S"`
 
 ## What's Changed in v3.10.1
@@ -138,7 +138,7 @@ Recoding streams has been updated to use MediaMTX with the option to delete olde
 
 Use `RECORD_ALL` or `RECORD_CAM_NAME` to enable recording.
 
-- `RECORD_PATH` Available variables are `%path` or `{cam_name}`, `%Y` `%m` `%d` `%H` `%M` `%S` `%f` `%s` (time in strftime format).
+- `RECORD_PATH` Available variables are `{CAM_NAME}` or `{cam_name}`, `%Y` `%m` `%d` `%H` `%M` `%S` `%f` `%s` (time in strftime format).
 - `RECORD_LENGTH` Length of each clip. Use `s` for seconds , `h` for hours. Defaults to `60s`
 - `RECORD_KEEP` Delete older clips. Use `s` for seconds , `h` for hours. Set to 0s to disable automatic deletion. Defaults to `0s`
 


### PR DESCRIPTION
This will prevent exceptions in the pruner (which could happen if two snapshots are requested in an overlap of the prune cycle... so one tries to delete a file another has already removed). These exceptions were causing the entire snapshot thread to die.

Also, made a change to keep a set of the file parents so we can only test if they need to be deleted (if empty) only AFTER pruning the entire set of files. This will ensure that we cleanup quicker.
