### PR TITLE
Update docker-compose.sample.yml to resolve IOTC timeouts.

### DIFF
--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -3,22 +3,23 @@ services:
         container_name: wyze-bridge
         restart: unless-stopped
         image: idisposablegithub365/wyze-bridge:latest
-        ports:
-            - 1935:1935 # RTMP rtmp://localhost:1935/mystream?user=myuser&pass=mypass
-            - 1936:1936 # RTMP rtmps://localhost:1936/mystream?user=myuser&pass=mypass
-            - 2935:2935 # RTMPS rtmps://localhost:2935/mystream?user=myuser&pass=mypass
-            - 2936:2936 # RTMPS rtmps://localhost:2936/mystream?user=myuser&pass=mypass
-            - 8000:8000/udp # RTSP UDP/RTP rtsp://localhost:8000/mystream
-            - 8001:8001/udp # RTSP UDP/RTCP rtsp://localhost:8001/mystream
-            - 8002:8002/udp # RTP Multicast
-            - 8003:8003/udp # RTP Multicast control
-            - 8189:8189/udp # WebRTC ICE/UDP
-            - 8322:8322 # TCP/TLS/RTSPS rtsps://localhost:8322/mystream
-            - 8554:8554 # RTSP rtsp://localhost:8554/mystream
-            - 8888:8888 # HLS http://localhost:8888/mystream
-            - 8889:8889 # WebRTC http://localhost:8889/mystream and http://localhost:8889/mystream/whep
-            - 8890:8890/udp # SRT UDP srt://localhost:8890?streamid=read:mystream:myuser:mypass
-            - 5000:5000 # WEB-UI http://localhost:5000/mystream
+        network_mode: host
+#        ports:
+#            - 1935:1935 # RTMP rtmp://localhost:1935/mystream?user=myuser&pass=mypass
+#            - 1936:1936 # RTMP rtmps://localhost:1936/mystream?user=myuser&pass=mypass
+#            - 2935:2935 # RTMPS rtmps://localhost:2935/mystream?user=myuser&pass=mypass
+#            - 2936:2936 # RTMPS rtmps://localhost:2936/mystream?user=myuser&pass=mypass
+#            - 8000:8000/udp # RTSP UDP/RTP rtsp://localhost:8000/mystream
+#            - 8001:8001/udp # RTSP UDP/RTCP rtsp://localhost:8001/mystream
+#            - 8002:8002/udp # RTP Multicast
+#            - 8003:8003/udp # RTP Multicast control
+#            - 8189:8189/udp # WebRTC ICE/UDP
+#            - 8322:8322 # TCP/TLS/RTSPS rtsps://localhost:8322/mystream
+#            - 8554:8554 # RTSP rtsp://localhost:8554/mystream
+#            - 8888:8888 # HLS http://localhost:8888/mystream
+#            - 8889:8889 # WebRTC http://localhost:8889/mystream and http://localhost:8889/mystream/whep
+#            - 8890:8890/udp # SRT UDP srt://localhost:8890?streamid=read:mystream:myuser:mypass
+#            - 5000:5000 # WEB-UI http://localhost:5000/mystream
         environment:
             # [OPTIONAL] Credentials can be set in the WebUI
             # API Key and ID can be obtained from the wyze dev portal: 


### PR DESCRIPTION
Updated configuration to add `network_mode: host` to resolve IOTC timeouts in Docker deployments.  Commented out the ports as they aren't used in network_mode: host.