### PR TITLE
fix: classify OG cameras (GW_GC1/GC2) as Gwell P2P even with empty LAN IP

### DIFF
--- a/cmd/wyze-bridge/main.go
+++ b/cmd/wyze-bridge/main.go
@@ -273,8 +273,8 @@ func startGwellProxyIfEnabled(ctx context.Context, cfg *config.Config, camMgr *c
 		log.Info().Msg("GWELL_ENABLED=false; GW_ cameras will be skipped")
 		return nil
 	}
-	// Only spawn if there's at least one OG-style Gwell camera (IsGwell
-	// and LAN-reachable). WebRTC-streamer cameras go to go2rtc's native
+	// Only spawn if there's at least one OG-style Gwell P2P camera.
+	// WebRTC-streamer cameras (doorbell lineage) go to go2rtc's native
 	// #format=wyze handler — gwell-proxy would just poll the shim and
 	// log "0 Gwell cameras, retrying in 30s" forever.
 	hasOG := false

--- a/internal/camera/gwell_test.go
+++ b/internal/camera/gwell_test.go
@@ -44,6 +44,32 @@ func TestManager_GwellOGCamera_RegistersPublishOnlySlot(t *testing.T) {
 	}
 }
 
+func TestManager_GwellOGCamera_EmptyLanIP_StillRegistersPublishOnlySlot(t *testing.T) {
+	// OG cameras route through gwell-proxy even when Wyze cloud reports
+	// empty LAN IP — gwell-proxy discovers the IP via P2P independently.
+	mgr, go2rtcAPI := newTestManager(t)
+	mgr.cfg.GwellEnabled = true
+
+	cam := NewCamera(wyzeapi.CameraInfo{
+		Name:  "og_no_ip",
+		MAC:   "AABBCCDDEE03",
+		Model: "GW_GC1",
+		LanIP: "", // empty — Wyze cloud doesn't always report OG LAN IPs
+	}, "hd", true, false)
+	mgr.cameras["og_no_ip"] = cam
+
+	mgr.connectCamera(context.Background(), cam)
+
+	if cam.GetState() != StateStreaming {
+		t.Errorf("state = %v, want Streaming (OG with empty IP should still use gwell)", cam.GetState())
+	}
+
+	streams, _ := go2rtcAPI.ListStreams(context.Background())
+	if _, has := streams["og_no_ip"]; !has {
+		t.Error("OG Gwell camera with empty LAN IP should have been registered via AddStream (publish-only slot)")
+	}
+}
+
 func TestManager_GwellWebRTCCamera_UsesWyzeFormatSource(t *testing.T) {
 	mgr, go2rtcAPI := newTestManager(t)
 	mgr.cfg.GwellEnabled = true

--- a/internal/camera/manager.go
+++ b/internal/camera/manager.go
@@ -222,12 +222,14 @@ func (m *Manager) ConnectAll(ctx context.Context) {
 // API. The stream URL is picked by protocol:
 //
 //   - TUTK: wyze:// source — go2rtc dials the camera directly.
-//   - WebRTC (GW_BE1 / GW_DBD / any Gwell model without a LAN IP):
+//   - WebRTC (GW_BE1 / GW_DBD doorbell lineage):
 //     webrtc:http://loopback/internal/wyze/webrtc/<cam>#format=wyze —
 //     go2rtc's native handler fetches the Wyze KVS signaling URL from
 //     our shim and dials Wyze's mars-webcsrv itself.
-//   - Gwell P2P (OG with LAN IP): empty URL — publish-only slot. The
-//     gwell-proxy sidecar's ffmpeg RTSP PUBLISH lands on this slot.
+//   - Gwell P2P (OG family: GW_GC1/GC2): empty URL — publish-only
+//     slot. The gwell-proxy sidecar's ffmpeg RTSP PUBLISH lands on
+//     this slot. OG cameras always route here even when the Wyze cloud
+//     reports an empty LAN IP — gwell-proxy discovers the IP over P2P.
 func (m *Manager) connectCamera(ctx context.Context, cam *Camera) {
 	m.changeState(cam, StateConnecting)
 

--- a/internal/webui/shim.go
+++ b/internal/webui/shim.go
@@ -46,12 +46,12 @@ func (s *Server) handleShimCameraList(w http.ResponseWriter, r *http.Request) {
 	// debugger.
 	all := s.camMgr.Cameras()
 	for _, cam := range all {
-		// gwell-proxy handles only Gwell-protocol cameras that actually
-		// use Gwell P2P for media — OG (GC1/GC2) with LAN IPs. The
-		// doorbell lineage (GW_BE1 / GW_DBD / any Gwell model without
-		// a LAN IP) streams over WebRTC; those go to wyze-webrtc-proxy
-		// and must be hidden from gwell-proxy to avoid a permanent
-		// Gwell-P2P retry loop that never produces video.
+	// gwell-proxy handles only Gwell-protocol cameras that use
+		// Gwell P2P for media — OG family (GC1/GC2). The doorbell
+		// lineage (GW_BE1 / GW_DBD) streams over WebRTC; those go
+		// to go2rtc's native #format=wyze handler and must be hidden
+		// from gwell-proxy to avoid a permanent Gwell-P2P retry loop
+		// that never produces video.
 		info := cam.GetInfo()
 		if info.IsGwell() && !info.IsWebRTCStreamer() {
 			ids = append(ids, info.MAC)

--- a/internal/webui/shim_test.go
+++ b/internal/webui/shim_test.go
@@ -68,11 +68,6 @@ func TestShim_CameraList_ExcludesWebRTCStreamers(t *testing.T) {
 		Name: "front_door", Model: "GW_BE1", MAC: "AABBCC001122", LanIP: "",
 	}, "hd", true, false)
 	srv.camMgr.InjectCamera("front_door", webrtcByModel)
-	// GW_GC1 with no LAN IP: WebRTC by heuristic.
-	webrtcByHeuristic := camera.NewCamera(wyzeapi.CameraInfo{
-		Name: "mystery_og", Model: "GW_GC1", MAC: "DDEEFF001122", LanIP: "",
-	}, "hd", true, false)
-	srv.camMgr.InjectCamera("mystery_og", webrtcByHeuristic)
 
 	w := httptest.NewRecorder()
 	srv.handleShimCameraList(w, newShimReq("GET", "/internal/wyze/Camera/CameraList"))
@@ -80,7 +75,27 @@ func TestShim_CameraList_ExcludesWebRTCStreamers(t *testing.T) {
 	var got []string
 	_ = json.NewDecoder(w.Body).Decode(&got)
 	if len(got) != 0 {
-		t.Errorf("expected empty list (both WebRTC-routed), got %v", got)
+		t.Errorf("expected empty list (WebRTC-routed doorbell), got %v", got)
+	}
+}
+
+func TestShim_CameraList_IncludesOGWithEmptyIP(t *testing.T) {
+	// OG cameras (GW_GC1/GC2) always route through gwell-proxy even
+	// when the Wyze cloud reports an empty LAN IP — gwell-proxy's
+	// DiscoverDevices recovers the IP over P2P independently.
+	srv, _ := testServer(t)
+	ogNoIP := camera.NewCamera(wyzeapi.CameraInfo{
+		Name: "og_cam", Model: "GW_GC1", MAC: "DDEEFF001122", LanIP: "",
+	}, "hd", true, false)
+	srv.camMgr.InjectCamera("og_cam", ogNoIP)
+
+	w := httptest.NewRecorder()
+	srv.handleShimCameraList(w, newShimReq("GET", "/internal/wyze/Camera/CameraList"))
+
+	var got []string
+	_ = json.NewDecoder(w.Body).Decode(&got)
+	if len(got) != 1 || got[0] != "DDEEFF001122" {
+		t.Errorf("want [DDEEFF001122] (OG always Gwell P2P), got %v", got)
 	}
 }
 

--- a/internal/wyzeapi/models.go
+++ b/internal/wyzeapi/models.go
@@ -37,6 +37,13 @@ var gwellModels = map[string]bool{
 	"GW_BE1": true, "GW_GC1": true, "GW_GC2": true, "GW_DBD": true,
 }
 
+// gwellP2PModels: OG-family cameras that always use Gwell P2P for
+// streaming, even when the Wyze cloud API reports an empty LAN IP.
+// gwell-proxy's own DiscoverDevices call recovers the IP over P2P.
+var gwellP2PModels = map[string]bool{
+	"GW_GC1": true, "GW_GC2": true,
+}
+
 // webRTCStreamerModels: Wyze cameras that stream live media over WebRTC
 // (Wyze's mars-webcsrv signaling + AWS TURN), handled by go2rtc's native
 // #format=wyze source. Doorbell lineage. OG cameras (GW_GC1/GC2) use
@@ -87,17 +94,26 @@ func (c CameraInfo) IsGwell() bool {
 	return gwellModels[c.Model]
 }
 
+// IsGwellP2P returns true for OG-family cameras that stream via Gwell
+// P2P on the LAN (handled by gwell-proxy), as opposed to doorbell-
+// lineage cameras which stream via WebRTC.
+func (c CameraInfo) IsGwellP2P() bool {
+	return gwellP2PModels[c.Model]
+}
+
 // IsWebRTCStreamer returns true when this camera streams via Wyze's
 // WebRTC path (served by go2rtc's native #format=wyze source). True if
-// either the model is in the allow-list OR the camera is Gwell-protocol
-// but has no LAN IP — the cloud not reporting a LAN IP is a reliable
-// signal for the doorbell lineage. OG cameras (LAN-direct Gwell P2P)
-// always have a LAN IP and stay on gwell-proxy.
+// the model is in the explicit allow-list OR the camera is Gwell-
+// protocol, not an OG-family model, and has no LAN IP — for non-OG
+// Gwell cameras, the cloud not reporting a LAN IP is a reliable signal
+// for the doorbell lineage. OG cameras always use Gwell P2P even when
+// the Wyze cloud doesn't report their LAN IP (gwell-proxy discovers it
+// over P2P independently).
 func (c CameraInfo) IsWebRTCStreamer() bool {
 	if webRTCStreamerModels[c.Model] {
 		return true
 	}
-	if c.IsGwell() && (c.LanIP == "" || c.LanIP == "0.0.0.0") {
+	if c.IsGwell() && !c.IsGwellP2P() && (c.LanIP == "" || c.LanIP == "0.0.0.0") {
 		return true
 	}
 	return false

--- a/internal/wyzeapi/models_test.go
+++ b/internal/wyzeapi/models_test.go
@@ -92,6 +92,50 @@ func TestCameraInfo_IsGwell(t *testing.T) {
 	}
 }
 
+func TestCameraInfo_IsGwellP2P(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"GW_GC1", true},
+		{"GW_GC2", true},
+		{"GW_BE1", false},
+		{"GW_DBD", false},
+		{"HL_CAM4", false},
+	}
+	for _, tt := range tests {
+		cam := CameraInfo{Model: tt.model}
+		if got := cam.IsGwellP2P(); got != tt.want {
+			t.Errorf("IsGwellP2P(%q) = %v, want %v", tt.model, got, tt.want)
+		}
+	}
+}
+
+func TestCameraInfo_IsWebRTCStreamer(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		ip    string
+		want  bool
+	}{
+		{"doorbell pro always webrtc", "GW_BE1", "", true},
+		{"doorbell duo always webrtc", "GW_DBD", "10.0.0.1", true},
+		{"OG with LAN IP is gwell p2p", "GW_GC1", "10.0.0.7", false},
+		{"OG with empty IP is still gwell p2p", "GW_GC1", "", false},
+		{"OG 3X with empty IP is still gwell p2p", "GW_GC2", "", false},
+		{"OG with 0.0.0.0 is still gwell p2p", "GW_GC1", "0.0.0.0", false},
+		{"TUTK camera is not webrtc", "HL_CAM4", "10.0.0.5", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cam := CameraInfo{Model: tt.model, LanIP: tt.ip}
+			if got := cam.IsWebRTCStreamer(); got != tt.want {
+				t.Errorf("IsWebRTCStreamer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCameraInfo_IsPanCam(t *testing.T) {
 	pan := CameraInfo{Model: "HL_PAN3"}
 	if !pan.IsPanCam() {


### PR DESCRIPTION
## Problem

The Wyze cloud API sometimes returns an empty LAN IP for OG cameras (GW_GC1/GC2). The existing `IsWebRTCStreamer()` fallback treated **any** Gwell camera with an empty LAN IP as a doorbell-lineage WebRTC streamer, which caused:

1. GW_GC1 misclassified as WebRTC → routed to go2rtc's `#format=wyze`
2. `startGwellProxyIfEnabled()` found no OG cameras → gwell-proxy never spawned
3. Camera fell back to WebRTC protocol → **black video**

## Fix

Add `gwellP2PModels` map for OG-family cameras (`GW_GC1`, `GW_GC2`) and exclude them from the empty-LAN-IP WebRTC fallback in `IsWebRTCStreamer()`. OG cameras always route to gwell-proxy regardless of LAN IP — gwell-proxy discovers the IP via P2P independently (`gwell.DiscoverDevices`).

### Changes

- **`internal/wyzeapi/models.go`**: Added `gwellP2PModels` map and `IsGwellP2P()` method. Modified `IsWebRTCStreamer()` to not classify OG models as WebRTC even with empty LAN IP.
- **`internal/wyzeapi/models_test.go`**: Added `TestCameraInfo_IsGwellP2P` and `TestCameraInfo_IsWebRTCStreamer` covering all model/IP combinations.
- **`internal/webui/shim_test.go`**: Fixed `TestShim_CameraList_ExcludesWebRTCStreamers` (removed incorrect GW_GC1 exclusion expectation), added `TestShim_CameraList_IncludesOGWithEmptyIP`.
- **`internal/camera/gwell_test.go`**: Added `TestManager_GwellOGCamera_EmptyLanIP_StillRegistersPublishOnlySlot`.
- Updated comments in `shim.go`, `manager.go`, and `main.go` to reflect that OG cameras don't require a LAN IP.

Fixes #110

Co-Authored-By: Oz <oz-agent@warp.dev>