### PR TITLE
Support Wyze GW_DUO (Gwell P2P) + fix Gwell go2rtc publish-slot & reconnect rate-limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ configure the path, the bridge routes based on the model.
   Gwell/IoTVideo LAN-direct UDP protocol. Enabled by default (set
   `GWELL_ENABLED=false` to opt out); the sidecar only actually spawns
   when an OG-family camera is discovered, so users without OG cameras
-  pay zero cost.
+  pay zero cost. Cameras whose LAN IP the Wyze cloud does not
+  report (e.g. `GW_DUO`) can be pinned via
+  `GWELL_LAN_IPS=DEVICEID=IP,DEVICEID=IP` (matched against the
+  device id) so the sidecar can seed its LAN-direct handshake.
 - **WebRTC (KVS)** — go2rtc's native `#format=wyze` handler dials
   Wyze's `wyze-mars-webcsrv.wyzecam.com` signaling server itself and
   speaks AWS-KVS WebRTC. Used by doorbell-lineage hardware that skips
@@ -107,6 +110,7 @@ configure the path, the bridge routes based on the model.
 | Wyze Cam Doorbell Duo | `GW_DBD` | WebRTC | Expected (same lineage) |
 | Wyze Cam OG | `GW_GC1` | Gwell P2P | Expected (LAN-direct UDP) |
 | Wyze Cam OG Telephoto 3X | `GW_GC2` | Gwell P2P | Expected (LAN-direct UDP) |
+| Wyze Cam Duo | `GW_DUO` | Gwell P2P | Confirmed - LAN-direct, requires `GWELL_LAN_IPS` |
 | Wyze Battery Cam Pro | `AN_RSCW` | — | Not supported |
 | Wyze Cam Floodlight Pro (2K) | `LD_CFP` | — | Not supported |
 

--- a/cmd/gwell-proxy/main.go
+++ b/cmd/gwell-proxy/main.go
@@ -338,7 +338,7 @@ func runCamera(client *wyzeShimClient, cameraID string,
 		if err != nil {
 			log.Printf("[%s] Stream error: %v", cameraID, err)
 			log.Printf("[%s] reconnect reason: stream_error", cameraID)
-			if derr := refreshDiscovery(client, cameraID, true); derr != nil {
+			if derr := refreshDiscovery(client, cameraID, false); derr != nil {
 				log.Printf("[%s] Re-discovery before reconnect failed: %v", cameraID, derr)
 			}
 		}

--- a/cmd/wyze-bridge/main.go
+++ b/cmd/wyze-bridge/main.go
@@ -616,6 +616,19 @@ func setupGo2RTC(ctx context.Context, cfg *config.Config, camMgr *camera.Manager
 		log.Info().Int("users", len(entries)).Msg("STREAM_AUTH configured")
 	}
 
+	// Pre-register Gwell cameras as empty publish-only slots so go2rtc
+	// holds the stream name and accepts the gwell-proxy's RTSP PUSH.
+	// Gwell streams have no go2rtc source (the proxy pushes into them);
+	// without a reserved slot the push is dropped ("broken pipe") and
+	// never reaches a consumer. TUTK/WebRTC cams get a real source via
+	// the runtime API instead.
+	for _, cam := range camMgr.Cameras() {
+		info := cam.GetInfo()
+		if info.IsGwell() && !info.IsWebRTCStreamer() {
+			configBuilder.AddStream(go2rtcmgr.StreamEntry{Name: cam.Name()})
+		}
+	}
+
 	go2rtcConfigPath := cfg.StateDir + "/go2rtc.yaml"
 	if err := configBuilder.WriteConfig(go2rtcConfigPath); err != nil {
 		log.Fatal().Err(err).Msg("write go2rtc config")

--- a/internal/wyzeapi/cameras.go
+++ b/internal/wyzeapi/cameras.go
@@ -2,6 +2,7 @@ package wyzeapi
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 )
@@ -73,6 +74,15 @@ func (c *Client) GetCameraList() ([]CameraInfo, error) {
 			DTLS:        getInt(params, "dtls") != 0,
 			ParentDTLS:  getInt(params, "main_device_dtls") != 0,
 			Online:      true,
+		}
+
+		// LAN-direct Gwell cameras (e.g. GW_DUO) get no LAN IP from the Wyze
+		// cloud. GWELL_LAN_IPS lets the operator pin them so the gwell-proxy
+		// establishes a LAN-direct session instead of the lossy relay.
+		if cam.LanIP == "" {
+			if ip := gwellLanIPOverride(cam.MAC); ip != "" {
+				cam.LanIP = ip
+			}
 		}
 
 		// Extract thumbnail
@@ -246,4 +256,22 @@ func (c *Client) GetCameraStream(cam CameraInfo) (map[string]interface{}, error)
 		return nil, fmt.Errorf("get_streams: %w", err)
 	}
 	return resp, nil
+}
+
+// gwellLanIPOverride returns an operator-pinned LAN IP for a Gwell camera
+// whose LAN IP the Wyze cloud does not report (e.g. GW_DUO). Configured
+// via the GWELL_LAN_IPS env var, formatted "DEVICEID=IP,DEVICEID=IP"
+// where DEVICEID matches CameraInfo.MAC (the id Wyze echoes for Gwell).
+func gwellLanIPOverride(mac string) string {
+	raw := os.Getenv("GWELL_LAN_IPS")
+	if raw == "" {
+		return ""
+	}
+	for _, pair := range strings.Split(raw, ",") {
+		kv := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+		if len(kv) == 2 && strings.EqualFold(strings.TrimSpace(kv[0]), mac) {
+			return strings.TrimSpace(kv[1])
+		}
+	}
+	return ""
 }

--- a/internal/wyzeapi/models.go
+++ b/internal/wyzeapi/models.go
@@ -34,7 +34,7 @@ var ModelNames = map[string]string{
 
 // Gwell-protocol cameras (not supported by go2rtc TUTK).
 var gwellModels = map[string]bool{
-	"GW_BE1": true, "GW_GC1": true, "GW_GC2": true, "GW_DBD": true,
+	"GW_BE1": true, "GW_GC1": true, "GW_GC2": true, "GW_DBD": true, "GW_DUO": true,
 }
 
 // webRTCStreamerModels: Wyze cameras that stream live media over WebRTC


### PR DESCRIPTION
## What
Adds Wyze **GW_DUO** support, and fixes two **general Gwell bugs** found while getting it working end-to-end (camera → gwell-proxy → go2rtc → Frigate).

## The four changes

**GW_DUO-specific**
1. **`gwellModels += GW_DUO`** (`internal/wyzeapi/models.go`) — classify GW_DUO as a Gwell-protocol camera.
2. **New `GWELL_LAN_IPS` env** (`DEVICEID=IP,...`, matched against `CameraInfo.MAC`) — the Wyze cloud returns an empty `LanIP` for GW_DUO; this pins it so the proxy establishes a LAN-direct session instead of falling back to relay. No-op when unset; only consulted when `LanIP == ""`.

**General Gwell fixes (affect all Gwell cameras, OG included)**
3. **Pre-register Gwell cameras as go2rtc publish-only slots** (`cmd/wyze-bridge/main.go`) — Gwell cams stream via an RTSP PUSH from gwell-proxy, but no go2rtc stream slot was reserved for them, so the push was dropped (`broken pipe`) and never reached a consumer. Each Gwell camera now gets an empty-source slot at startup so go2rtc holds the name and accepts the publish.
4. **Reconnect uses the cached P2P server instead of forcing fresh discovery** (`cmd/gwell-proxy/main.go`) — `runCamera` force-re-discovered on *every* reconnect, re-hammering the P2P discovery server (~every 70s for a flapping camera) and tripping server-side rate-limiting, which made that camera's next handshake time out (`CALLING ACK peer=0.0.0.0`) — a self-sustaining loop. With two identical cameras, the one that reconnected got stuck at `peer=0.0.0.0` while the stable one was fine. Reconnect now uses the cached server (falls back to discovery only when the cache is stale), matching the file's own "fresh discovery when both cameras are down" comment.

## Testing
Two GW_DUO + a V4 + a Pan V3 on one account:
- Both GW_DUO classified `protocol: gwell`, both in the shim CameraList.
- With `GWELL_LAN_IPS` set, both establish **LAN-direct** (`bestLAN` = the camera's own LAN IP, verified against ARP) and stream into Frigate at ~5 fps.
- Before #3 the gwell PUSH died with `broken pipe`; after, it lands as a go2rtc producer.
- Before #4 one of two identical GW_DUO cams was permanently stuck at `peer=0.0.0.0` while the other worked; after, both connect.

## Notes
- README table uses "Wyze Cam Duo" for `GW_DUO` — adjust the retail name if needed.
- #3 and #4 are not GW_DUO-specific.
