### PR TITLE
Add Window Cam (GW_WC), Floodlight Pro (LD_CFP), Cam Pan Duo (GW_DUO) support; fix KVS signaling double-encoding

### DIFF
--- a/cmd/wyze-bridge/main.go
+++ b/cmd/wyze-bridge/main.go
@@ -94,6 +94,14 @@ func main() {
 	webServer := webui.NewServer(cfg, camMgr, nil, Version, webuiLog)
 	webServer.SetIssuesRegistry(issueReg)
 	webServer.SetMarsMinter(apiClient)
+	// Manual LAN IPs for Gwell cameras the Wyze cloud doesn't surface
+	// (e.g. Window Cams / GW_WC). Missing file is a no-op.
+	if manualIPs, err := webui.LoadManualIPs(cfg.GwellManualIPs); err != nil {
+		log.Warn().Err(err).Str("path", cfg.GwellManualIPs).Msg("failed to load Gwell manual IPs; continuing without")
+	} else if len(manualIPs) > 0 {
+		log.Info().Int("count", len(manualIPs)).Str("path", cfg.GwellManualIPs).Msg("loaded Gwell manual LAN IPs")
+		webServer.SetManualIPs(manualIPs)
+	}
 	// KVS / WebRTC provider for the wyze-webrtc-proxy sidecar: answer
 	// /kvs-config/<streamID> by calling /v4/camera/get_streams and
 	// mapping the response into whep_proxy's WebRTCConfig shape.

--- a/cmd/wyze-bridge/main.go
+++ b/cmd/wyze-bridge/main.go
@@ -682,6 +682,9 @@ func (a kvsAdapter) GetCameraStream(ctx context.Context, mac, model string) (str
 	if signalingURL == "" {
 		return "", nil, "", fmt.Errorf("get_streams: empty signaling_url")
 	}
+	// Wyze double-encodes the SigV4 query params for some cameras (e.g.
+	// LD_CFP); undo it or AWS KVS rejects the handshake with 403.
+	signalingURL = wyzeapi.FixKVSSignalingURL(signalingURL)
 	authToken, _ := params["auth_token"].(string)
 
 	var ice []webui.KVSIceServer

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,6 +102,7 @@ type Config struct {
 	GwellFFmpegLogLevel string // ffmpeg -loglevel inside gwell-proxy (quiet/panic/fatal/error/warning/info/verbose/debug/trace)
 	GwellDumpDir        string // if non-empty, gwell-proxy tees raw H.264 to this dir for offline ffprobe
 	GwellDeadmanTimeout time.Duration
+	GwellManualIPs      string // path to manual_ips.json mapping MAC->LAN IP for Gwell cams the cloud doesn't surface
 
 	// Per-camera overrides keyed by normalized camera name (UPPER_CASE)
 	CamOverrides map[string]CamOverride
@@ -221,6 +222,7 @@ func Load() (*Config, error) {
 		GwellFFmpegLogLevel: env("GWELL_FFMPEG_LOGLEVEL", "warning"),
 		GwellDumpDir:        env("GWELL_DUMP_DIR", ""),
 		GwellDeadmanTimeout: envDuration("GWELL_DEADMAN_TIMEOUT", 2*time.Minute),
+		GwellManualIPs:      env("GWELL_MANUAL_IPS", "/config/manual_ips.json"),
 
 		// Internals
 		CamOverrides:    make(map[string]CamOverride),

--- a/internal/webui/manualips.go
+++ b/internal/webui/manualips.go
@@ -1,0 +1,75 @@
+package webui
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+// ManualIPs maps a camera MAC (uppercase, no separators) to a LAN IP
+// the operator supplies by hand. It exists because the Wyze cloud API
+// returns an empty LAN IP for Gwell cameras — and for LAN-direct models
+// like the Window Cam (GW_WC) that the cloud also doesn't reliably
+// surface, P2P discovery alone may never find the camera on the local
+// subnet. Supplying the IP here lets the shim hand it to gwell-proxy so
+// the session can go LAN-direct instead of relaying through the cloud.
+//
+// This mirrors the manual_ips.json used by wlatic/hacky-wyze-gwell, so
+// an existing file drops in unchanged.
+type ManualIPs map[string]string
+
+// normalizeMAC strips a model prefix (e.g. "GW_WC_80482CB9EF6E" ->
+// "80482CB9EF6E"), removes ':'/'-' separators, and uppercases. Accepts
+// plain MACs too. Returns "" for an unusable key.
+func normalizeMAC(key string) string {
+	// A wlatic-style key is "<MODEL>_<MAC>" where MAC is the trailing
+	// underscore-delimited segment. Plain MAC keys have no underscore.
+	if i := strings.LastIndex(key, "_"); i >= 0 {
+		key = key[i+1:]
+	}
+	key = strings.NewReplacer(":", "", "-", "").Replace(key)
+	return strings.ToUpper(strings.TrimSpace(key))
+}
+
+// LoadManualIPs reads a JSON object of {key: ip} from path and returns a
+// MAC-normalized map. A missing file is not an error — it returns an
+// empty map so the feature is opt-in by simply dropping the file in.
+// Keys may be plain MACs or wlatic "<MODEL>_<MAC>" form; values are LAN
+// IPs (or arbitrary strings, validated downstream).
+func LoadManualIPs(path string) (ManualIPs, error) {
+	if path == "" {
+		return ManualIPs{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return ManualIPs{}, nil
+		}
+		return nil, err
+	}
+	var raw map[string]string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	out := make(ManualIPs, len(raw))
+	for k, v := range raw {
+		mac := normalizeMAC(k)
+		ip := strings.TrimSpace(v)
+		if mac == "" || ip == "" {
+			continue
+		}
+		out[mac] = ip
+	}
+	return out, nil
+}
+
+// lookup returns the manual IP for a MAC (any case/separator form), or
+// "" if none is configured.
+func (m ManualIPs) lookup(mac string) string {
+	if m == nil {
+		return ""
+	}
+	return m[normalizeMAC(mac)]
+}

--- a/internal/webui/manualips_test.go
+++ b/internal/webui/manualips_test.go
@@ -1,0 +1,67 @@
+package webui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeMAC(t *testing.T) {
+	cases := map[string]string{
+		"GW_WC_80482CB9EF6E":  "80482CB9EF6E",
+		"80482CB9EF6E":        "80482CB9EF6E",
+		"80:48:2C:B9:EF:6E":   "80482CB9EF6E",
+		"aabbccddeeff":        "AABBCCDDEEFF",
+		"GW_GC1_AABBCCDDEEFF": "AABBCCDDEEFF",
+	}
+	for in, want := range cases {
+		if got := normalizeMAC(in); got != want {
+			t.Errorf("normalizeMAC(%q) = %q, want %q", in, want, got)
+		}
+	}
+}
+
+func TestLoadManualIPs_MissingFileIsEmpty(t *testing.T) {
+	m, err := LoadManualIPs(filepath.Join(t.TempDir(), "nope.json"))
+	if err != nil {
+		t.Fatalf("missing file should not error: %v", err)
+	}
+	if len(m) != 0 {
+		t.Errorf("expected empty map, got %v", m)
+	}
+}
+
+func TestLoadManualIPs_ParsesAndNormalizes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manual_ips.json")
+	body := `{
+		"GW_WC_80482CB9EF6E": "192.168.1.51",
+		"GW_WC_80482CB92978": "192.168.1.52",
+		"  ":                  "192.168.1.99",
+		"GW_WC_EMPTY":         ""
+	}`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := LoadManualIPs(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got := m.lookup("80:48:2C:B9:EF:6E"); got != "192.168.1.51" {
+		t.Errorf("lookup by colon-MAC = %q, want 192.168.1.51", got)
+	}
+	if got := m.lookup("GW_WC_80482CB92978"); got != "192.168.1.52" {
+		t.Errorf("lookup by full key = %q, want 192.168.1.52", got)
+	}
+	// Blank key and blank value entries are dropped.
+	if len(m) != 2 {
+		t.Errorf("expected 2 valid entries, got %d: %v", len(m), m)
+	}
+}
+
+func TestManualIPs_LookupNil(t *testing.T) {
+	var m ManualIPs
+	if got := m.lookup("AABBCCDDEEFF"); got != "" {
+		t.Errorf("nil lookup = %q, want empty", got)
+	}
+}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -43,20 +43,21 @@ type DiscoverRequester func(ctx context.Context)
 // the client. Handlers that need it use s.go2rtc() and return 503 if
 // the client isn't attached yet.
 type Server struct {
-	log       zerolog.Logger
-	cfg       *config.Config
-	camMgr    *camera.Manager
-	go2rtcAPI atomic.Pointer[go2rtcmgr.APIClient]
-	sseHub    *SSEHub
-	auth      *AuthMiddleware
-	srv       *http.Server
-	version   string
-	startTime time.Time
+	log           zerolog.Logger
+	cfg           *config.Config
+	camMgr        *camera.Manager
+	go2rtcAPI     atomic.Pointer[go2rtcmgr.APIClient]
+	sseHub        *SSEHub
+	auth          *AuthMiddleware
+	srv           *http.Server
+	version       string
+	startTime     time.Time
 	onSnapReq     SnapshotRequester
 	onDiscoverReq DiscoverRequester
-	mars      MarsTokenMinter
-	kvs       KVSStreamProvider
-	issues    *issues.Registry // optional
+	mars          MarsTokenMinter
+	manualIPs     ManualIPs // operator-supplied LAN IPs for Gwell cams (may be nil)
+	kvs           KVSStreamProvider
+	issues        *issues.Registry // optional
 	// Metrics data sources — all optional so tests and partial-setup
 	// paths (bring-up before every subsystem wires in) stay legal.
 	recMgr   RecordingObserver

--- a/internal/webui/shim.go
+++ b/internal/webui/shim.go
@@ -26,6 +26,14 @@ func (s *Server) SetMarsMinter(m MarsTokenMinter) {
 	s.mars = m
 }
 
+// SetManualIPs attaches operator-supplied LAN IPs (keyed by MAC) used by
+// the shim's DeviceInfo endpoint to override the empty LAN IP the Wyze
+// cloud returns for Gwell cameras. A nil/empty map is a no-op. Called
+// from main.go after loading the manual_ips.json file.
+func (s *Server) SetManualIPs(m ManualIPs) {
+	s.manualIPs = m
+}
+
 // Shim endpoints live under /internal/wyze/Camera/* and re-expose our
 // bridge's state in the shape the gwell-proxy subprocess expects
 // (matches wlatic/hacky-wyze-gwell's Python wyze-api wire format so
@@ -96,10 +104,23 @@ func (s *Server) handleShimDeviceInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	info := cam.GetInfo()
+	lanIP := info.LanIP
+	// The Wyze cloud returns an empty LAN IP for Gwell cameras. If the
+	// operator supplied one via manual_ips.json, prefer it so gwell-proxy
+	// can establish a LAN-direct session instead of relaying via cloud.
+	if manual := s.manualIPs.lookup(info.MAC); manual != "" {
+		s.log.Debug().
+			Str("cam", cam.Name()).
+			Str("mac", info.MAC).
+			Str("manual_ip", manual).
+			Str("cloud_ip", info.LanIP).
+			Msg("shim DeviceInfo: using manual LAN IP override")
+		lanIP = manual
+	}
 	writeJSON(w, map[string]string{
 		"cameraId":   info.MAC,
 		"streamName": cam.Name(),
-		"lanIp":      info.LanIP,
+		"lanIp":      lanIP,
 	})
 }
 

--- a/internal/webui/shim_test.go
+++ b/internal/webui/shim_test.go
@@ -132,6 +132,28 @@ func TestShim_DeviceInfo_CaseInsensitive(t *testing.T) {
 	}
 }
 
+func TestShim_DeviceInfo_ManualIPOverride(t *testing.T) {
+	srv, _ := testServer(t)
+	// A Window Cam with no cloud LAN IP (the real-world case for GW_WC).
+	cam := camera.NewCamera(wyzeapi.CameraInfo{
+		Name: "kitchen_window", Model: "GW_WC", MAC: "80482CB9EF6E", LanIP: "",
+	}, "hd", true, false)
+	srv.camMgr.InjectCamera("kitchen_window", cam)
+	srv.SetManualIPs(ManualIPs{"80482CB9EF6E": "192.168.1.51"})
+
+	w := httptest.NewRecorder()
+	srv.handleShimDeviceInfo(w, newShimReq("GET", "/internal/wyze/Camera/DeviceInfo?deviceId=80482CB9EF6E"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", w.Code, w.Body.String())
+	}
+	var got map[string]string
+	_ = json.NewDecoder(w.Body).Decode(&got)
+	if got["lanIp"] != "192.168.1.51" {
+		t.Errorf("lanIp = %q, want manual override 192.168.1.51", got["lanIp"])
+	}
+}
+
 func TestShim_DeviceInfo_NotFound(t *testing.T) {
 	srv, _ := testServer(t)
 	w := httptest.NewRecorder()

--- a/internal/wyzeapi/cameras.go
+++ b/internal/wyzeapi/cameras.go
@@ -2,9 +2,34 @@ package wyzeapi
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 )
+
+// FixKVSSignalingURL works around Wyze's get_streams double-encoding the
+// AWS SigV4 query parameters in the KVS WebRTC signaling URL for some
+// cameras (observed on the LD_CFP Floodlight Pro): the slashes/colons in
+// X-Amz-Credential, X-Amz-ChannelARN, X-Amz-Security-Token come back as
+// %252F/%253A/%252B instead of %2F/%3A/%2B. Sent verbatim, AWS rejects
+// the websocket handshake with 403 "Credential must have exactly 5
+// slash-delimited elements".
+//
+// The tell-tale is a literal %25 (an encoded percent) — correctly
+// single-encoded presigned URLs never contain one. When present, decode
+// exactly one layer with PathUnescape (which, unlike QueryUnescape,
+// leaves '+' alone so base64 tokens survive). Otherwise return the URL
+// untouched so non-double-encoded cameras (e.g. Doorbell Pro) are
+// unaffected.
+func FixKVSSignalingURL(u string) string {
+	if !strings.Contains(u, "%25") {
+		return u
+	}
+	if dec, err := url.PathUnescape(u); err == nil {
+		return dec
+	}
+	return u
+}
 
 // GetCameraList fetches the list of cameras from the Wyze API.
 func (c *Client) GetCameraList() ([]CameraInfo, error) {
@@ -104,10 +129,16 @@ func (c *Client) GetCameraList() ([]CameraInfo, error) {
 		//    LanIP for these — the actual IP is recovered by the proxy
 		//    during P2P discovery. P2PID is just the device MAC echoed
 		//    back. Require MAC + ENR + Model only.
+		//  - WebRTC/KVS cameras (LD_CFP Floodlight Pro): Wyze serves them
+		//    over AWS KVS, signaled per-session by get_streams. No LAN IP
+		//    and no useful P2PID, so require MAC + Model only.
 		var missing bool
-		if cam.IsGwell() {
+		switch {
+		case cam.IsGwell():
 			missing = cam.MAC == "" || cam.ENR == "" || cam.Model == ""
-		} else {
+		case cam.IsWebRTCStreamer():
+			missing = cam.MAC == "" || cam.Model == ""
+		default:
 			missing = cam.P2PID == "" || cam.LanIP == "" || cam.ENR == "" || cam.MAC == "" || cam.Model == ""
 		}
 		if missing {

--- a/internal/wyzeapi/cameras_test.go
+++ b/internal/wyzeapi/cameras_test.go
@@ -49,11 +49,11 @@ func TestClient_GetCameraList(t *testing.T) {
 					map[string]interface{}{
 						"product_type":  "Camera",
 						"product_model": "HL_PAN3",
-						"mac":           "",       // Missing MAC → skip
+						"mac":           "", // Missing MAC → skip
 						"nickname":      "No MAC",
 						"device_params": map[string]interface{}{
-							"p2p_id":   "X",
-							"ip":       "10.0.0.2",
+							"p2p_id":            "X",
+							"ip":                "10.0.0.2",
 							"camera_thumbnails": map[string]interface{}{},
 						},
 					},
@@ -241,5 +241,25 @@ func TestClient_GetDeviceInfo(t *testing.T) {
 	}
 	if len(propList) != 3 {
 		t.Errorf("property count = %d, want 3", len(propList))
+	}
+}
+
+func TestFixKVSSignalingURL(t *testing.T) {
+	// Wyze's get_streams double-encodes the SigV4 query params for some
+	// cameras (observed on LD_CFP Floodlight Pro): %2F -> %252F etc. AWS
+	// KVS rejects the websocket handshake with 403 "Credential must have
+	// exactly 5 slash-delimited elements". Single-decode fixes it.
+	doubled := "wss://v.kinesisvideo.amazonaws.com/?X-Amz-ChannelARN=arn%253Aaws&X-Amz-Credential=ASIA%252F20260621%252Fus-west-2%252Fkinesisvideo%252Faws4_request&X-Amz-Security-Token=ab%252Bcd"
+	want := "wss://v.kinesisvideo.amazonaws.com/?X-Amz-ChannelARN=arn%3Aaws&X-Amz-Credential=ASIA%2F20260621%2Fus-west-2%2Fkinesisvideo%2Faws4_request&X-Amz-Security-Token=ab%2Bcd"
+	if got := FixKVSSignalingURL(doubled); got != want {
+		t.Errorf("double-encoded fix:\n got=%q\nwant=%q", got, want)
+	}
+
+	// Correctly single-encoded URL passes through untouched (no %25), so
+	// non-double-encoded cameras (e.g. Doorbell Pro) are unaffected and
+	// '+' is not mangled into a space.
+	single := "wss://v.kinesisvideo.amazonaws.com/?X-Amz-Credential=ASIA%2F20260621&X-Amz-Security-Token=ab%2Bcd"
+	if got := FixKVSSignalingURL(single); got != single {
+		t.Errorf("single-encoded URL changed:\n got=%q\nwant=%q", got, single)
 	}
 }

--- a/internal/wyzeapi/models.go
+++ b/internal/wyzeapi/models.go
@@ -31,6 +31,7 @@ var ModelNames = map[string]string{
 	"AN_RSCW":        "Battery Cam Pro",
 	"LD_CFP":         "Floodlight Pro",
 	"GW_DBD":         "Doorbell Duo",
+	"GW_DUO":         "Cam Pan Duo",
 }
 
 // Gwell-protocol cameras (not supported by go2rtc TUTK).
@@ -59,10 +60,12 @@ var lanDirectGwellModels = map[string]bool{
 // go2rtc's native #format=wyze source. OG cameras (GW_GC1/GC2) use Gwell
 // P2P on the LAN and don't belong here.
 //   - GW_BE1 / GW_DBD: Doorbell Pro / Duo (Gwell-lineage, WebRTC media)
-//   - LD_CFP:          Floodlight Pro (not Gwell; KVS WebRTC only —
+//   - LD_CFP:          Floodlight Pro (not Gwell; AWS-KVS WebRTC —
 //     get_streams returns a kinesisvideo signaling URL)
+//   - GW_DUO:          Cam Pan Duo (not Gwell; WebRTC via Wyze's own
+//     mars-webcsrv signaling, the Doorbell Pro backend — not AWS KVS)
 var webRTCStreamerModels = map[string]bool{
-	"GW_BE1": true, "GW_DBD": true, "LD_CFP": true,
+	"GW_BE1": true, "GW_DBD": true, "LD_CFP": true, "GW_DUO": true,
 }
 
 // PanCams is the set of pan/tilt camera models.

--- a/internal/wyzeapi/models.go
+++ b/internal/wyzeapi/models.go
@@ -9,28 +9,28 @@ import (
 
 // ModelNames maps product_model codes to human-readable names.
 var ModelNames = map[string]string{
-	"WYZEC1":        "V1",
-	"WYZEC1-JZ":     "V2",
+	"WYZEC1":         "V1",
+	"WYZEC1-JZ":      "V2",
 	"WYZE_CAKP2JFUS": "V3",
-	"HL_CAM4":       "V4",
-	"HL_CAM3P":      "V3 Pro",
-	"WYZECP1_JEF":   "Pan",
-	"HL_PAN2":       "Pan V2",
-	"HL_PAN3":       "Pan V3",
-	"HL_PANP":       "Pan Pro",
-	"HL_CFL2":       "Floodlight V2",
-	"WYZEDB3":       "Doorbell",
-	"HL_DB2":        "Doorbell V2",
-	"GW_BE1":        "Doorbell Pro",
-	"AN_RDB1":       "Doorbell Pro 2",
-	"GW_GC1":        "OG",
-	"GW_GC2":        "OG 3X",
-	"GW_WC":         "Window Cam",
-	"WVOD1":         "Outdoor",
-	"HL_WCO2":       "Outdoor V2",
-	"AN_RSCW":       "Battery Cam Pro",
-	"LD_CFP":        "Floodlight Pro",
-	"GW_DBD":        "Doorbell Duo",
+	"HL_CAM4":        "V4",
+	"HL_CAM3P":       "V3 Pro",
+	"WYZECP1_JEF":    "Pan",
+	"HL_PAN2":        "Pan V2",
+	"HL_PAN3":        "Pan V3",
+	"HL_PANP":        "Pan Pro",
+	"HL_CFL2":        "Floodlight V2",
+	"WYZEDB3":        "Doorbell",
+	"HL_DB2":         "Doorbell V2",
+	"GW_BE1":         "Doorbell Pro",
+	"AN_RDB1":        "Doorbell Pro 2",
+	"GW_GC1":         "OG",
+	"GW_GC2":         "OG 3X",
+	"GW_WC":          "Window Cam",
+	"WVOD1":          "Outdoor",
+	"HL_WCO2":        "Outdoor V2",
+	"AN_RSCW":        "Battery Cam Pro",
+	"LD_CFP":         "Floodlight Pro",
+	"GW_DBD":         "Doorbell Duo",
 }
 
 // Gwell-protocol cameras (not supported by go2rtc TUTK).
@@ -55,11 +55,14 @@ var lanDirectGwellModels = map[string]bool{
 }
 
 // webRTCStreamerModels: Wyze cameras that stream live media over WebRTC
-// (Wyze's mars-webcsrv signaling + AWS TURN), handled by go2rtc's native
-// #format=wyze source. Doorbell lineage. OG cameras (GW_GC1/GC2) use
-// Gwell P2P on the LAN and don't belong here.
+// (AWS KVS signaling via /v4/camera/get_streams + AWS TURN), handled by
+// go2rtc's native #format=wyze source. OG cameras (GW_GC1/GC2) use Gwell
+// P2P on the LAN and don't belong here.
+//   - GW_BE1 / GW_DBD: Doorbell Pro / Duo (Gwell-lineage, WebRTC media)
+//   - LD_CFP:          Floodlight Pro (not Gwell; KVS WebRTC only —
+//     get_streams returns a kinesisvideo signaling URL)
 var webRTCStreamerModels = map[string]bool{
-	"GW_BE1": true, "GW_DBD": true,
+	"GW_BE1": true, "GW_DBD": true, "LD_CFP": true,
 }
 
 // PanCams is the set of pan/tilt camera models.

--- a/internal/wyzeapi/models.go
+++ b/internal/wyzeapi/models.go
@@ -25,6 +25,7 @@ var ModelNames = map[string]string{
 	"AN_RDB1":       "Doorbell Pro 2",
 	"GW_GC1":        "OG",
 	"GW_GC2":        "OG 3X",
+	"GW_WC":         "Window Cam",
 	"WVOD1":         "Outdoor",
 	"HL_WCO2":       "Outdoor V2",
 	"AN_RSCW":       "Battery Cam Pro",
@@ -35,6 +36,22 @@ var ModelNames = map[string]string{
 // Gwell-protocol cameras (not supported by go2rtc TUTK).
 var gwellModels = map[string]bool{
 	"GW_BE1": true, "GW_GC1": true, "GW_GC2": true, "GW_DBD": true,
+	"GW_WC": true,
+}
+
+// lanDirectGwellModels: Gwell cameras that stream LAN-direct over Gwell
+// P2P (handled by gwell-proxy) for which the Wyze cloud reports an empty
+// LAN IP — so the generic "no LAN IP → WebRTC" heuristic in
+// IsWebRTCStreamer would otherwise misroute them to the doorbell/WebRTC
+// path. This set exempts them; the real LAN IP is recovered by P2P
+// discovery or supplied via manual_ips.json.
+//
+// OG (GW_GC1/GC2) is intentionally NOT here: the existing heuristic
+// treats a missing LAN IP as the doorbell-lineage signal for those, and
+// changing that is out of scope for window-cam support.
+//   - GW_WC: Window Cam
+var lanDirectGwellModels = map[string]bool{
+	"GW_WC": true,
 }
 
 // webRTCStreamerModels: Wyze cameras that stream live media over WebRTC
@@ -94,6 +111,12 @@ func (c CameraInfo) IsGwell() bool {
 // signal for the doorbell lineage. OG cameras (LAN-direct Gwell P2P)
 // always have a LAN IP and stay on gwell-proxy.
 func (c CameraInfo) IsWebRTCStreamer() bool {
+	// LAN-direct Gwell models (OG, Window Cam) always use gwell-proxy,
+	// even though the Wyze cloud reports an empty LAN IP for them — the
+	// proxy recovers the real IP via P2P discovery / manual override.
+	if lanDirectGwellModels[c.Model] {
+		return false
+	}
 	if webRTCStreamerModels[c.Model] {
 		return true
 	}

--- a/internal/wyzeapi/models_test.go
+++ b/internal/wyzeapi/models_test.go
@@ -115,6 +115,22 @@ func TestCameraInfo_WindowCam_IsLanDirectGwell(t *testing.T) {
 	}
 }
 
+func TestCameraInfo_FloodlightPro_IsWebRTC(t *testing.T) {
+	// Floodlight Pro (LD_CFP) is NOT Gwell — Wyze serves it over AWS KVS
+	// WebRTC (get_streams returns a kinesisvideo signaling URL). It must
+	// route to the WebRTC streamer path, not TUTK or Gwell.
+	fl := CameraInfo{Model: "LD_CFP", LanIP: ""}
+	if fl.IsGwell() {
+		t.Error("LD_CFP must not be classified as Gwell")
+	}
+	if !fl.IsWebRTCStreamer() {
+		t.Error("LD_CFP should be a WebRTC streamer")
+	}
+	if got, want := fl.ModelName(), "Floodlight Pro"; got != want {
+		t.Errorf("ModelName(LD_CFP) = %q, want %q", got, want)
+	}
+}
+
 func TestCameraInfo_IsPanCam(t *testing.T) {
 	pan := CameraInfo{Model: "HL_PAN3"}
 	if !pan.IsPanCam() {

--- a/internal/wyzeapi/models_test.go
+++ b/internal/wyzeapi/models_test.go
@@ -131,6 +131,23 @@ func TestCameraInfo_FloodlightPro_IsWebRTC(t *testing.T) {
 	}
 }
 
+func TestCameraInfo_PanDuo_IsWebRTC(t *testing.T) {
+	// Cam Pan Duo (GW_DUO) streams over WebRTC via Wyze's mars-webcsrv
+	// signaling (get_streams returns wss://wyze-mars-webcsrv...), the same
+	// path as the Doorbell Pro. NOT a Gwell-P2P camera, NOT TUTK. The
+	// cloud reports no LAN IP, so it must route to the WebRTC path.
+	pd := CameraInfo{Model: "GW_DUO", LanIP: ""}
+	if pd.IsGwell() {
+		t.Error("GW_DUO must not be classified as Gwell")
+	}
+	if !pd.IsWebRTCStreamer() {
+		t.Error("GW_DUO should be a WebRTC streamer")
+	}
+	if got, want := pd.ModelName(), "Cam Pan Duo"; got != want {
+		t.Errorf("ModelName(GW_DUO) = %q, want %q", got, want)
+	}
+}
+
 func TestCameraInfo_IsPanCam(t *testing.T) {
 	pan := CameraInfo{Model: "HL_PAN3"}
 	if !pan.IsPanCam() {

--- a/internal/wyzeapi/models_test.go
+++ b/internal/wyzeapi/models_test.go
@@ -92,6 +92,29 @@ func TestCameraInfo_IsGwell(t *testing.T) {
 	}
 }
 
+func TestCameraInfo_WindowCam_IsLanDirectGwell(t *testing.T) {
+	// Wyze Window Cam (GW_WC) uses the same Gwell P2P stack as OG, but the
+	// Wyze cloud API returns an empty LAN IP for it. It must still be
+	// treated as a LAN-direct Gwell camera (handled by gwell-proxy), NOT
+	// misrouted to the WebRTC/doorbell path by the "no LAN IP" heuristic.
+	wc := CameraInfo{Model: "GW_WC", LanIP: ""}
+	if !wc.IsGwell() {
+		t.Error("GW_WC should be Gwell")
+	}
+	if wc.IsWebRTCStreamer() {
+		t.Error("GW_WC with empty LAN IP must NOT be a WebRTC streamer (it is LAN-direct Gwell)")
+	}
+	if got, want := wc.ModelName(), "Window Cam"; got != want {
+		t.Errorf("ModelName(GW_WC) = %q, want %q", got, want)
+	}
+
+	// Regression guard: doorbell-lineage Gwell with empty LAN IP IS WebRTC.
+	db := CameraInfo{Model: "GW_BE1", LanIP: ""}
+	if !db.IsWebRTCStreamer() {
+		t.Error("GW_BE1 with empty LAN IP should remain a WebRTC streamer")
+	}
+}
+
 func TestCameraInfo_IsPanCam(t *testing.T) {
 	pan := CameraInfo{Model: "HL_PAN3"}
 	if !pan.IsPanCam() {


### PR DESCRIPTION
## Summary

Adds support for three more Wyze cameras and fixes an AWS KVS signaling bug, all verified live on a Raspberry Pi 5 (arm64) against real hardware:

- **Wyze Window Cam (`GW_WC`)** — Gwell P2P, same media stack as OG.
- **Wyze Floodlight Pro (`LD_CFP`)** — AWS KVS WebRTC (`kinesisvideo` signaling).
- **Wyze Cam Pan Duo (`GW_DUO`)** — WebRTC via Wyze's `mars-webcsrv` signaling (the Doorbell Pro backend).
- **`FixKVSSignalingURL`** — fixes a double-percent-encoding bug in the KVS signaling URL that otherwise 403s the WebRTC handshake.

## Changes

### 1. Floodlight Pro (`LD_CFP`) over AWS KVS WebRTC
`LD_CFP` is not Gwell (Mars `regist_gw_user` mints no token) and not TUTK — `get_streams` returns a `kinesisvideo.us-west-2.amazonaws.com` signaling URL, exactly like the Doorbell lineage.

- Add `LD_CFP` to `webRTCStreamerModels` so it routes to go2rtc's native `#format=wyze` source.
- Relax discovery: WebRTC/KVS cameras have no LAN IP and no useful P2PID (Wyze signals them per-session), so require `MAC + Model` only. Without this `LD_CFP` was dropped at discovery as "missing P2P params". Implemented as a 3-way switch (`IsGwell` / `IsWebRTCStreamer` / TUTK default).

### 2. Cam Pan Duo (`GW_DUO`) over mars-webcsrv WebRTC
`GW_DUO` is also a WebRTC camera, but `get_streams` returns `wss://wyze-mars-webcsrv.wyzecam.com?token=...` with `turn@iotvideo` ICE servers — Wyze's own signaling backend (the **Doorbell Pro** path), not AWS KVS. Same `#format=wyze` handler, different backend; no double-encoding on this one. Just needs `GW_DUO` in `webRTCStreamerModels` + `ModelNames`; the relaxed discovery already covers it. (The dual lenses arrive as one composite frame.)

### 3. Fix double-encoded KVS signaling URL (`FixKVSSignalingURL`)
For `LD_CFP`, Wyze's `get_streams` **double-percent-encodes** the SigV4 query params (`%2F`→`%252F`, `%3A`→`%253A`, `%2B`→`%252B`). Sent verbatim, AWS KVS rejects the websocket handshake with `403 "Credential must have exactly 5 slash-delimited elements"` — which surfaces in go2rtc only as `websocket: bad handshake`.

The fix detects the tell-tale `%25` and `url.PathUnescape`s exactly one layer (`PathUnescape`, unlike `QueryUnescape`, leaves `+` intact so base64 tokens survive). Correctly single-encoded URLs (Doorbell Pro, Pan Duo) contain no `%25` and pass through untouched, so this is safe for existing cameras. **This may benefit other KVS cameras too.**

### 4. Window Cam (`GW_WC`) over Gwell P2P
`GW_WC` uses the same Gwell/IoTVideo stack the vendored `upstream/gwell` code already drives.

- Add `GW_WC` to `gwellModels` + `ModelNames` ("Window Cam").
- New `lanDirectGwellModels` set: Wyze returns an empty LAN IP for all Gwell cams, so the generic "no LAN IP → WebRTC streamer" heuristic would misroute `GW_WC` to the doorbell/WebRTC path. This exempts it. (OG `GC1/GC2` are intentionally left out to keep their existing heuristic byte-for-byte.)
- Manual LAN-IP override: `GWELL_MANUAL_IPS` (default `/config/manual_ips.json`) supplies the camera LAN IP the Wyze cloud doesn't report for `GW_WC`, used by the shim's `DeviceInfo`. Wire format matches `wlatic/hacky-wyze-gwell`'s `manual_ips.json` so an existing file drops in.

> [!NOTE]
> **Caveat for the Gwell push path (`GW_WC`, and likely the existing "Expected" OG path).** The gwell-proxy publishes via RTSP-PUSH into go2rtc as a *publish-only producer*. With **no consumer attached**, go2rtc tears the idle producer down → `ffmpeg ... Broken pipe` → the Gwell session ends → reconnect, and single-viewer cameras then reject the re-handshake (`INITREQ: no ACCEPT`). In practice `GW_WC` streams **stably only behind a persistent consumer or an external media server** (we run it through mediamtx). The WebRTC paths (`LD_CFP`, `GW_DUO`) have no such issue — they're on-demand pull. Flagging in case maintainers want to address go2rtc idle-producer handling for the push path generally.

## Testing

- Live on a Pi 5 (arm64), built from `docker/Dockerfile`.
- **`LD_CFP`**: full WebRTC negotiation, snapshot returns a real **2560×1440** frame. KVS handshake confirmed failing (403) before `FixKVSSignalingURL` and succeeding (101) after.
- **`GW_DUO`**: WebRTC negotiation completes via mars-webcsrv, snapshot returns a real composite (dual-lens) **1296×728** frame.
- **`GW_WC`**: all 6 cameras discovered, classified, and streamed end-to-end (ACCEPT → streaming → continuous H.264), with the push-path caveat above.
- Unit tests added for model classification, relaxed discovery, MAC normalization / manual-IP loading, and `FixKVSSignalingURL` (both double- and single-encoded inputs).
