### PR TITLE
Release v4.5.0

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -296,35 +296,56 @@ Two long-lived branches, two add-on channels.
 4. HA users on the edge channel see an "update available" within
    minutes.
 
-The base of the edge version (`X.Y.Z-edge`, the part before the
-timestamp) lives in `home_assistant/wyze_bridge_edge/config.yaml` on
-`dev`. Bump it there when you start a new minor cycle (e.g.
-`4.3.0-edge`); CI strips any existing `.YYYYMMDD.HHMM` suffix before
-appending the current timestamp so you never get compounding suffixes.
+When you start a new minor cycle, bump **both** on `dev` in the same
+commit:
+
+- `home_assistant/wyze_bridge_edge/config.yaml` → new edge base
+	(e.g. `4.5.0-edge` — CI strips any prior `.YYYYMMDD.HHMM` and
+	appends the current timestamp).
+- `home_assistant/wyze_bridge/config.yaml` → the eventual stable
+	version (e.g. `4.5.0`).
+
+Both `CHANGELOG.md` files should get the matching top entry at the
+same time so edge users see accurate notes on the first edge build
+and stable users see them the moment the merge lands.
+
+**Why bump stable on `dev`?** The `addon-stable` job builds the moment
+`main` is pushed and reads `home_assistant/wyze_bridge/config.yaml`
+at that commit to derive the image tag. If the merge lands with the
+old version still in the file, `addon-stable` publishes the new
+code under the *old* tag — HA users on the previous release get
+silent code updates without a version bump, and the eventual `v4.5.0`
+tag's `version-bump` job commits with `[skip ci]` so no build fires
+for the new tag. Keeping the config in lockstep on `dev` makes the
+merge idempotent: `addon-stable` publishes `4.5.0` on merge, the tag
+build publishes `4.5.0` again (harmless, same tag), and `version-bump`
+becomes a no-op.
 
 ### Promoting an edge release to stable
 
-When `dev` is ready to become the new stable:
+When `dev` is ready to become the new stable (both config.yaml files
+already bumped per the note above):
 
 ```bash
 # 1. Open the release PR
 gh pr create --base main --head dev \
-  --title "Release v4.2.0" \
-  --body "## Changes since 4.1.0\n\n- ..."
+  --title "Release v4.5.0" \
+  --body "## Changes since 4.4.x\n\n- ..."
 
 # 2. Review + merge the PR in the GitHub UI or via
 gh pr merge --merge   # or --squash if you prefer linear history on main
 
-# 3. Tag the release on main
+# 3. Tag the release on main (must match stable config.yaml's version)
 git checkout main && git pull
-git tag v4.2.0
-git push origin v4.2.0
+git tag v4.5.0
+git push origin v4.5.0
 ```
 
-The tag push triggers CI's `version-bump` job, which rewrites
-`home_assistant/wyze_bridge/config.yaml` `version:` to `4.2.0` and
-commits it back to `main`. The stable add-on image is published with
-that tag.
+The tag push re-triggers `addon-stable` (same version, same image —
+harmless idempotent republish) and fires the `version-bump` job. If
+the stable `config.yaml` version already matches the tag, `version-bump`
+is a no-op; if it doesn't, `version-bump` writes the tag's version
+into `config.yaml` and commits it back to `main` with `[skip ci]`.
 
 **Conflict note:** PR merges rarely conflict on
 `home_assistant/wyze_bridge_edge/config.yaml` because `dev` doesn't

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -92,7 +92,7 @@ go2rtc's RTSP server uses a single username/password for all streams. Per-camera
 
 ### Changed: Camera names
 
-In the previous version a camera with an embedded space would have the space replaced by a hypen `-`. In the code the space is replaced by an underscore `_`. So camera `Front Door` becomes `front_door` (not `front-door`) so you might need to adjust dashboards or actions.
+The Python bridge replaced spaces in camera names with a hyphen (`-`); the Go bridge replaces them with an underscore (`_`). So camera `Front Door` is now published at `rtsp://…/front_door` (not `front-door`). Adjust anything that hard-codes the old URL — Frigate `cameras.*.ffmpeg.inputs.path`, Home Assistant `camera:` platform entries, Lovelace dashboards, Node-RED nodes, and any browser bookmarks.
 
 ### Changed: WebUI Appearance
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -192,26 +192,32 @@ either of the above.
 
 Wyze's early-2025 firmware update disabled TUTK on newer `HL_CAM4`
 units — cameras that previously worked stop connecting with
-`IOTC_ER_TIMEOUT` even while the Wyze app plays them fine. The Wyze
-cloud continues to serve the same stream via WebRTC (the same
-mars-webcsrv backend the doorbells use), so the fix is a routing
-flip, not a code change on our side. Set:
+`IOTC_ER_TIMEOUT` even while the Wyze app plays them fine.
 
-```
-MODEL_OVERRIDES=HL_CAM4:is_webrtc=true
-```
+**4.5+ handles this automatically.** After
+`TUTK_FALLBACK_THRESHOLD` consecutive TUTK failures (default `5`)
+the bridge auto-promotes the camera to the WebRTC path (Wyze's
+mars-webcsrv backend, same one the doorbells use). No config
+changes required. The promotion is per-camera and sticky for the
+process lifetime; a restart re-probes TUTK from scratch so a
+firmware downgrade recovers on its own. Watch for the
+`camera/fallback/<name>` entry in `/metrics` and `webrtc (forced)`
+on the camera row.
 
-(HA add-on users: **Camera Model Registry → Model Overrides** →
-`model=HL_CAM4, is_webrtc=true`.) Cameras on pre-4.52 firmware that
-still speak TUTK don't need this — leaving them on TUTK is faster
-and stays LAN-local. The issues registry auto-hints this workaround
-when it detects sustained TUTK failures on an `HL_CAM4`.
+**Opt-outs and manual override.** Set `TUTK_FALLBACK_THRESHOLD=0`
+to disable the auto-fallback entirely (chronic-error hint remains).
+If you want to pin a specific camera to WebRTC without waiting for
+the streak to hit the threshold, use
+`MODEL_OVERRIDES=HL_CAM4:is_webrtc=true` (HA: **Camera Model
+Registry → Model Overrides** → `model=HL_CAM4, is_webrtc=true`) —
+manual overrides win over the auto-promotion. Cameras on pre-4.52
+firmware that still speak TUTK never trip the streak and stay on
+the faster LAN-local path.
 
 Tracked in [#117](https://github.com/IDisposable/docker-wyze-bridge/issues/117),
 [#92](https://github.com/IDisposable/docker-wyze-bridge/issues/92),
-[#87](https://github.com/IDisposable/docker-wyze-bridge/issues/87);
-runtime auto-fallback is planned for 4.5 so the override becomes
-unnecessary.
+[#87](https://github.com/IDisposable/docker-wyze-bridge/issues/87).
+Design + testing notes in `DOCS/TUTK_WEBRTC_FALLBACK_DESIGN.md`.
 
 ## Default Behavior Changes (4.0)
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -186,6 +186,33 @@ Previously unsupported in the Python bridge, now handled in two ways:
 Battery Cam Pro, Floodlight Pro (LD_CFP) — different protocol than
 either of the above.
 
+## Known Issues
+
+### V4 (`HL_CAM4`) TUTK timeout on newer firmware
+
+Wyze's early-2025 firmware update disabled TUTK on newer `HL_CAM4`
+units — cameras that previously worked stop connecting with
+`IOTC_ER_TIMEOUT` even while the Wyze app plays them fine. The Wyze
+cloud continues to serve the same stream via WebRTC (the same
+mars-webcsrv backend the doorbells use), so the fix is a routing
+flip, not a code change on our side. Set:
+
+```
+MODEL_OVERRIDES=HL_CAM4:is_webrtc=true
+```
+
+(HA add-on users: **Camera Model Registry → Model Overrides** →
+`model=HL_CAM4, is_webrtc=true`.) Cameras on pre-4.52 firmware that
+still speak TUTK don't need this — leaving them on TUTK is faster
+and stays LAN-local. The issues registry auto-hints this workaround
+when it detects sustained TUTK failures on an `HL_CAM4`.
+
+Tracked in [#117](https://github.com/IDisposable/docker-wyze-bridge/issues/117),
+[#92](https://github.com/IDisposable/docker-wyze-bridge/issues/92),
+[#87](https://github.com/IDisposable/docker-wyze-bridge/issues/87);
+runtime auto-fallback is planned for 4.5 so the override becomes
+unnecessary.
+
 ## Default Behavior Changes (4.0)
 
 The rewrite is a good opportunity to pick sensible defaults. If you

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ configure the path, the bridge routes based on the model.
 | Wyze Cam V2 | `WYZEC1-JZ` | TUTK | Should work |
 | Wyze Cam V3 | `WYZE_CAKP2JFUS` | TUTK | Confirmed |
 | Wyze Cam V3 Pro (2K) | `HL_CAM3P` | TUTK | Should work |
-| Wyze Cam V4 (2K) | `HL_CAM4` | TUTK | Confirmed |
+| Wyze Cam V4 (2K) | `HL_CAM4` | TUTK / WebRTC | Confirmed on FW <4.52; newer FW blocks TUTK — override to WebRTC (see below) |
 | Wyze Cam Floodlight | `WYZE_CAKP2JFUS` | TUTK | Should work |
 | Wyze Cam Floodlight V2 (2K) | `HL_CFL2` | TUTK | Should work |
 | Wyze Cam Pan | `WYZECP1_JEF` | TUTK | Should work |
@@ -118,6 +118,24 @@ configure the path, the bridge routes based on the model.
 "Expected" means the code path is plumbed and equivalent hardware is
 known to work, but we don't own a unit to confirm end-to-end. Bug
 reports welcome.
+
+### V4 (`HL_CAM4`) on new firmware
+
+Wyze pushed a firmware update in early 2025 that disabled the TUTK
+protocol on newer V4 units — cameras that used to work stop
+connecting with `IOTC_ER_TIMEOUT` even though the Wyze app still
+plays them. The stream is still available via Wyze's WebRTC backend
+(same one the doorbells use). Flip the route with a model override:
+
+```
+MODEL_OVERRIDES=HL_CAM4:is_webrtc=true
+```
+
+In the HA add-on: **Camera Model Registry → Model Overrides** →
+`model=HL_CAM4, is_webrtc=true`. Cameras on older FW (pre-4.52) that
+still speak TUTK don't need this; the auto-hint in the issues
+registry surfaces the workaround when it detects chronic TUTK
+timeouts on an `HL_CAM4`.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ configure the path, the bridge routes based on the model.
 | Wyze Cam V2 | `WYZEC1-JZ` | TUTK | Should work |
 | Wyze Cam V3 | `WYZE_CAKP2JFUS` | TUTK | Confirmed |
 | Wyze Cam V3 Pro (2K) | `HL_CAM3P` | TUTK | Should work |
-| Wyze Cam V4 (2K) | `HL_CAM4` | TUTK / WebRTC | Confirmed on FW <4.52; newer FW blocks TUTK — override to WebRTC (see below) |
+| Wyze Cam V4 (2K) | `HL_CAM4` | TUTK / WebRTC | Confirmed on FW <4.52; newer FW blocks TUTK, bridge auto-fallbacks to WebRTC (see below) |
 | Wyze Cam Floodlight | `WYZE_CAKP2JFUS` | TUTK | Should work |
 | Wyze Cam Floodlight V2 (2K) | `HL_CFL2` | TUTK | Should work |
 | Wyze Cam Pan | `WYZECP1_JEF` | TUTK | Should work |
@@ -125,17 +125,20 @@ Wyze pushed a firmware update in early 2025 that disabled the TUTK
 protocol on newer V4 units — cameras that used to work stop
 connecting with `IOTC_ER_TIMEOUT` even though the Wyze app still
 plays them. The stream is still available via Wyze's WebRTC backend
-(same one the doorbells use). Flip the route with a model override:
+(same one the doorbells use).
 
-```
-MODEL_OVERRIDES=HL_CAM4:is_webrtc=true
-```
+**4.5+ recovers these cameras automatically.** After
+`TUTK_FALLBACK_THRESHOLD` (default `5`) consecutive TUTK failures the
+bridge promotes the camera to the WebRTC path for the rest of the
+process lifetime. No config change needed. Watch `/metrics` for the
+`camera/fallback/<name>` issue and the `webrtc (forced)` label on
+the camera row.
 
-In the HA add-on: **Camera Model Registry → Model Overrides** →
-`model=HL_CAM4, is_webrtc=true`. Cameras on older FW (pre-4.52) that
-still speak TUTK don't need this; the auto-hint in the issues
-registry surfaces the workaround when it detects chronic TUTK
-timeouts on an `HL_CAM4`.
+To pin a camera to WebRTC immediately (skipping the streak), set
+`MODEL_OVERRIDES=HL_CAM4:is_webrtc=true` (HA add-on: **Camera Model
+Registry → Model Overrides** → `model=HL_CAM4, is_webrtc=true`). To
+disable the auto-fallback entirely, set `TUTK_FALLBACK_THRESHOLD=0` —
+the chronic-error hint still points at the manual override.
 
 ## Quick Start
 

--- a/cmd/wyze-bridge/main.go
+++ b/cmd/wyze-bridge/main.go
@@ -116,12 +116,16 @@ func main() {
 		func(camName string, errorCount int) {
 			detail := "Backoff is capped at 5min; reconnects keep firing. Check logs for the underlying go2rtc / stream error."
 			// Model-specific hints for known-bad routing defaults.
-			// See MIGRATION.md "Known Issues" for the full list.
+			// See MIGRATION.md "Known Issues" for the full list. When
+			// TUTK_FALLBACK_THRESHOLD > 0 the runtime auto-promotes
+			// affected cameras before this fires, so hitting the
+			// chronic threshold means fallback either failed or was
+			// disabled — the manual override still helps.
 			if cam := camMgr.GetCamera(camName); cam != nil {
 				info := cam.GetInfo()
 				switch info.Model {
 				case "HL_CAM4":
-					if !info.IsWebRTCStreamer() {
+					if !info.IsWebRTCStreamer() && !cam.ForceWebRTC() {
 						detail = "V4 on newer Wyze firmware (~2025-02+) blocks TUTK. Try MODEL_OVERRIDES=HL_CAM4:is_webrtc=true (HA: Camera Model Registry → Model Overrides → model=HL_CAM4, is_webrtc=true). See MIGRATION.md → Known Issues."
 					}
 				}
@@ -137,6 +141,17 @@ func main() {
 		},
 		func(camName string) { issueReg.Resolve("camera/chronic/" + camName) },
 	)
+
+	camMgr.OnProtocolFallback(func(camName, oldProtocol, newProtocol string, streak int) {
+		issueReg.Report(issues.Issue{
+			ID:       "camera/fallback/" + camName,
+			Severity: issues.SeverityWarn,
+			Scope:    "camera",
+			Camera:   camName,
+			Message:  fmt.Sprintf("Auto-promoted %s → %s after %d consecutive failures", oldProtocol, newProtocol, streak),
+			Detail:   "Wyze's newer firmware disables TUTK on some models (notably HL_CAM4); the WebRTC path via mars-webcsrv still works. Persists for this process; restart to re-probe TUTK. Set TUTK_FALLBACK_THRESHOLD=0 to disable the auto-promotion.",
+		})
+	})
 
 	webuiLog := log.With().Str("c", "webui").Logger()
 	webServer := webui.NewServer(webui.Options{

--- a/cmd/wyze-bridge/main.go
+++ b/cmd/wyze-bridge/main.go
@@ -114,13 +114,25 @@ func main() {
 	camMgr := camera.NewManager(cfg, apiClient, nil, camLog)
 	camMgr.OnChronicError(
 		func(camName string, errorCount int) {
+			detail := "Backoff is capped at 5min; reconnects keep firing. Check logs for the underlying go2rtc / stream error."
+			// Model-specific hints for known-bad routing defaults.
+			// See MIGRATION.md "Known Issues" for the full list.
+			if cam := camMgr.GetCamera(camName); cam != nil {
+				info := cam.GetInfo()
+				switch info.Model {
+				case "HL_CAM4":
+					if !info.IsWebRTCStreamer() {
+						detail = "V4 on newer Wyze firmware (~2025-02+) blocks TUTK. Try MODEL_OVERRIDES=HL_CAM4:is_webrtc=true (HA: Camera Model Registry → Model Overrides → model=HL_CAM4, is_webrtc=true). See MIGRATION.md → Known Issues."
+					}
+				}
+			}
 			issueReg.Report(issues.Issue{
 				ID:       "camera/chronic/" + camName,
 				Severity: issues.SeverityWarn,
 				Scope:    "camera",
 				Camera:   camName,
 				Message:  fmt.Sprintf("Camera stuck in error after %d consecutive failed connects", errorCount),
-				Detail:   "Backoff is capped at 5min; reconnects keep firing. Check logs for the underlying go2rtc / stream error.",
+				Detail:   detail,
 			})
 		},
 		func(camName string) { issueReg.Resolve("camera/chronic/" + camName) },

--- a/home_assistant/wyze_bridge/CHANGELOG.md
+++ b/home_assistant/wyze_bridge/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 4.4.2
+
+Reliability + doc pass driven by open issue triage.
+
+- **Stream auto-recovery** ([#100](https://github.com/IDisposable/docker-wyze-bridge/issues/100)):
+	HealthCheck now routes dropped streams through the error/backoff
+	path so the 10s reconnect ticker actually picks them up (was
+	logging "reconnecting" without reconnecting). `connectCamera` also
+	clears any prior go2rtc entry before re-registering so a stuck
+	source pool gets fully torn down. Rename-in-Wyze-app orphans are
+	reaped by MAC each discovery cycle instead of accumulating stale
+	streams forever.
+- **Grid audio stays muted** ([#112](https://github.com/IDisposable/docker-wyze-bridge/issues/112)):
+	`<video-rtc>` now honors a `muted` attribute proactively, so the
+	grid stays quiet even after the browser grants autoplay
+	permission from a single-camera click. Detail page is unchanged.
+- **Camera-name doc** ([#99](https://github.com/IDisposable/docker-wyze-bridge/issues/99)):
+	Expanded MIGRATION.md → "Changed: Camera names" with the specific
+	Frigate / HA `camera:` / Lovelace / Node-RED surfaces to update.
+- **HL_CAM4 (V4) auto-hint** ([#117](https://github.com/IDisposable/docker-wyze-bridge/issues/117),
+	[#92](https://github.com/IDisposable/docker-wyze-bridge/issues/92),
+	[#87](https://github.com/IDisposable/docker-wyze-bridge/issues/87)):
+	Wyze's early-2025 firmware disabled TUTK on newer V4 units. The
+	issues registry now emits a targeted hint when it sees chronic
+	TUTK timeouts on an `HL_CAM4` — the fix is a one-line override
+	(`MODEL_OVERRIDES=HL_CAM4:is_webrtc=true`) documented in README +
+	MIGRATION.md → "Known Issues". Runtime auto-fallback is designed
+	for 4.5.
+
 ## 4.4.1
 
 Hotfix for [#119](https://github.com/IDisposable/docker-wyze-bridge/issues/119):

--- a/home_assistant/wyze_bridge/CHANGELOG.md
+++ b/home_assistant/wyze_bridge/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 4.5.0
+
+Runtime **TUTK → WebRTC auto-fallback** for cameras Wyze crippled
+via firmware. When a TUTK-path camera fails to stream 5 times in
+a row (configurable via `TUTK_FALLBACK_THRESHOLD`), the bridge
+promotes it to the WebRTC path for the rest of the process
+lifetime — no operator intervention, no config edits, no restart.
+Primarily targets `HL_CAM4` (Wyze V4) hit by the early-2025
+firmware update but works for any model Wyze exposes over
+mars-webcsrv.
+
+- New env var `TUTK_FALLBACK_THRESHOLD` (default `5`, `0` disables).
+- Per-camera `forceWebRTC` flag surfaces in `/api/metrics` as
+	`protocol_forced: true` and on the metrics page as `webrtc
+	(forced)`.
+- Auto-promotion fires the issues registry entry
+	`camera/fallback/<name>` (warn severity) so the change is
+	visible in `/metrics`, `/api/health`, and
+	`sensor.wyze_bridge_config_errors`.
+- Manual `MODEL_OVERRIDES=HL_CAM4:is_webrtc=true` still works and
+	takes precedence — operator intent wins over auto-fallback.
+- Full design + testing notes in `DOCS/TUTK_WEBRTC_FALLBACK_DESIGN.md`.
+- MIGRATION.md → Known Issues updated to reflect auto-recovery
+	is now the default fix path.
+
 ## 4.4.2
 
 Reliability + doc pass driven by open issue triage.

--- a/home_assistant/wyze_bridge/config.yaml
+++ b/home_assistant/wyze_bridge/config.yaml
@@ -5,7 +5,7 @@ description: >-
 slug: wyze_bridge
 url: https://github.com/IDisposable/docker-wyze-bridge
 image: ghcr.io/idisposable/docker-wyze-bridge-homeassistant
-version: 4.4.1
+version: 4.4.2
 stage: stable
 arch:
   - amd64

--- a/home_assistant/wyze_bridge/config.yaml
+++ b/home_assistant/wyze_bridge/config.yaml
@@ -5,7 +5,7 @@ description: >-
 slug: wyze_bridge
 url: https://github.com/IDisposable/docker-wyze-bridge
 image: ghcr.io/idisposable/docker-wyze-bridge-homeassistant
-version: 4.4.2
+version: 4.5.0
 stage: stable
 arch:
   - amd64

--- a/home_assistant/wyze_bridge_edge/CHANGELOG.md
+++ b/home_assistant/wyze_bridge_edge/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 4.4.2-edge
+
+Reliability + doc pass driven by open issue triage.
+
+- **Stream auto-recovery** ([#100](https://github.com/IDisposable/docker-wyze-bridge/issues/100)):
+	HealthCheck now routes dropped streams through the error/backoff
+	path so the 10s reconnect ticker actually picks them up (was
+	logging "reconnecting" without reconnecting). `connectCamera` also
+	clears any prior go2rtc entry before re-registering so a stuck
+	source pool gets fully torn down. Rename-in-Wyze-app orphans are
+	reaped by MAC each discovery cycle instead of accumulating stale
+	streams forever.
+- **Grid audio stays muted** ([#112](https://github.com/IDisposable/docker-wyze-bridge/issues/112)):
+	`<video-rtc>` now honors a `muted` attribute proactively, so the
+	grid stays quiet even after the browser grants autoplay
+	permission from a single-camera click. Detail page is unchanged.
+- **Camera-name doc** ([#99](https://github.com/IDisposable/docker-wyze-bridge/issues/99)):
+	Expanded MIGRATION.md → "Changed: Camera names" with the specific
+	Frigate / HA `camera:` / Lovelace / Node-RED surfaces to update.
+- **HL_CAM4 (V4) auto-hint** ([#117](https://github.com/IDisposable/docker-wyze-bridge/issues/117),
+	[#92](https://github.com/IDisposable/docker-wyze-bridge/issues/92),
+	[#87](https://github.com/IDisposable/docker-wyze-bridge/issues/87)):
+	Wyze's early-2025 firmware disabled TUTK on newer V4 units. The
+	issues registry now emits a targeted hint when it sees chronic
+	TUTK timeouts on an `HL_CAM4` — the fix is a one-line override
+	(`MODEL_OVERRIDES=HL_CAM4:is_webrtc=true`) documented in README +
+	MIGRATION.md → "Known Issues". Runtime auto-fallback is designed
+	for 4.5.
+
 ## 4.4.1-edge
 
 Hotfix for [#119](https://github.com/IDisposable/docker-wyze-bridge/issues/119):

--- a/home_assistant/wyze_bridge_edge/CHANGELOG.md
+++ b/home_assistant/wyze_bridge_edge/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 4.5.0-edge
+
+Runtime **TUTK → WebRTC auto-fallback** for cameras Wyze crippled
+via firmware. When a TUTK-path camera fails to stream 5 times in
+a row (configurable via `TUTK_FALLBACK_THRESHOLD`), the bridge
+promotes it to the WebRTC path for the rest of the process
+lifetime — no operator intervention, no config edits, no restart.
+Primarily targets `HL_CAM4` (Wyze V4) hit by the early-2025
+firmware update but works for any model Wyze exposes over
+mars-webcsrv.
+
+- New env var `TUTK_FALLBACK_THRESHOLD` (default `5`, `0` disables).
+- Per-camera `forceWebRTC` flag surfaces in `/api/metrics` as
+	`protocol_forced: true` and on the metrics page as `webrtc
+	(forced)`.
+- Auto-promotion fires the issues registry entry
+	`camera/fallback/<name>` (warn severity) so the change is
+	visible in `/metrics`, `/api/health`, and
+	`sensor.wyze_bridge_config_errors`.
+- Manual `MODEL_OVERRIDES=HL_CAM4:is_webrtc=true` still works and
+	takes precedence — operator intent wins over auto-fallback.
+- Full design + testing notes in `DOCS/TUTK_WEBRTC_FALLBACK_DESIGN.md`.
+- MIGRATION.md → Known Issues updated to reflect auto-recovery
+	is now the default fix path.
+
 ## 4.4.2-edge
 
 Reliability + doc pass driven by open issue triage.

--- a/home_assistant/wyze_bridge_edge/config.yaml
+++ b/home_assistant/wyze_bridge_edge/config.yaml
@@ -6,7 +6,7 @@ description: >-
 slug: wyze_bridge_edge
 url: https://github.com/IDisposable/docker-wyze-bridge/tree/dev
 image: ghcr.io/idisposable/docker-wyze-bridge-homeassistant-edge
-version: 4.4.0-edge.20260701.0028
+version: 4.4.2-edge
 stage: experimental
 arch:
   - amd64

--- a/home_assistant/wyze_bridge_edge/config.yaml
+++ b/home_assistant/wyze_bridge_edge/config.yaml
@@ -6,7 +6,7 @@ description: >-
 slug: wyze_bridge_edge
 url: https://github.com/IDisposable/docker-wyze-bridge/tree/dev
 image: ghcr.io/idisposable/docker-wyze-bridge-homeassistant-edge
-version: 4.4.2-edge.20260701.0343
+version: 4.5.0-edge
 stage: experimental
 arch:
   - amd64

--- a/internal/camera/camera.go
+++ b/internal/camera/camera.go
@@ -47,6 +47,14 @@ type Camera struct {
 	ConnectedAt time.Time
 	LastSeen    time.Time
 	ErrorCount  int
+	// tutkFailStreak counts consecutive TUTK-path connect failures.
+	// Reset on StateStreaming. Once it crosses the manager's threshold
+	// the camera flips to forceWebRTC. See DOCS/TUTK_WEBRTC_FALLBACK_DESIGN.md.
+	tutkFailStreak int
+	// forceWebRTC overrides the model registry's routing default and
+	// pins this camera to the WebRTC path. Sticky for the process
+	// lifetime; a restart re-probes TUTK from scratch.
+	forceWebRTC bool
 	mu          sync.RWMutex
 }
 
@@ -76,6 +84,7 @@ func (c *Camera) SetState(s State) {
 	if s == StateStreaming {
 		c.ConnectedAt = time.Now()
 		c.ErrorCount = 0
+		c.tutkFailStreak = 0
 	}
 	c.LastSeen = time.Now()
 }
@@ -87,6 +96,51 @@ func (c *Camera) IncrementError() time.Duration {
 	c.ErrorCount++
 	c.State = StateError
 	return c.BackoffDuration()
+}
+
+// IncrementTUTKFail bumps the TUTK-path failure streak and returns
+// the new count. Reset via SetState(StateStreaming) or ResetTUTKFail.
+func (c *Camera) IncrementTUTKFail() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tutkFailStreak++
+	return c.tutkFailStreak
+}
+
+// TUTKFailStreak returns the current consecutive-TUTK-failure count.
+func (c *Camera) TUTKFailStreak() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.tutkFailStreak
+}
+
+// ResetTUTKFail clears the TUTK-failure streak without changing state.
+// Called when the routing decision no longer involves TUTK (e.g. after
+// promotion to WebRTC) so a later demotion starts from zero.
+func (c *Camera) ResetTUTKFail() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tutkFailStreak = 0
+}
+
+// ForceWebRTC returns true when this camera has been runtime-promoted
+// past the model registry's default routing.
+func (c *Camera) ForceWebRTC() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.forceWebRTC
+}
+
+// SetForceWebRTC pins (or unpins) this camera to the WebRTC path.
+// Idempotent; returns true when the flag actually changed.
+func (c *Camera) SetForceWebRTC(on bool) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.forceWebRTC == on {
+		return false
+	}
+	c.forceWebRTC = on
+	return true
 }
 
 // BackoffDuration returns the current backoff duration based on error count.
@@ -182,6 +236,10 @@ type Snapshot struct {
 	ErrorCount  int
 	ConnectedAt time.Time
 	LastSeen    time.Time
+	// ForceWebRTC reflects the runtime TUTK→WebRTC fallback. Rendered
+	// as `protocol_forced` in /api/metrics so operators can tell the
+	// registry default from the promoted-at-runtime state.
+	ForceWebRTC bool
 }
 
 // Snapshot returns a consistent view of the camera under RLock.
@@ -197,6 +255,7 @@ func (c *Camera) Snapshot() Snapshot {
 		ErrorCount:  c.ErrorCount,
 		ConnectedAt: c.ConnectedAt,
 		LastSeen:    c.LastSeen,
+		ForceWebRTC: c.forceWebRTC,
 	}
 }
 

--- a/internal/camera/integration_test.go
+++ b/internal/camera/integration_test.go
@@ -158,16 +158,29 @@ func TestManager_HealthCheck(t *testing.T) {
 	mgr, _ := newTestManager(t)
 	ctx := context.Background()
 
-	// Add a camera that thinks it's streaming but isn't in go2rtc
+	// Camera the manager thinks is streaming but that go2rtc has no
+	// entry for. HealthCheck should flip it to Error so the 10s
+	// reconnect ticker picks it up (issue #100 fix — StateOffline
+	// wasn't in reconnectErrored's filter).
 	cam := NewCamera(wyzeapi.CameraInfo{Name: "ghost_cam"}, "hd", true, false)
 	cam.SetState(StateStreaming)
 	mgr.cameras["ghost_cam"] = cam
 
+	var transitions []State
+	mgr.OnStateChange(func(c *Camera, old, new State) {
+		transitions = append(transitions, new)
+	})
+
 	mgr.HealthCheck(ctx)
 
-	// Should have been marked offline
-	if cam.GetState() != StateOffline {
-		t.Errorf("ghost cam should be offline, got %v", cam.GetState())
+	if cam.GetState() != StateError {
+		t.Errorf("ghost cam should be Error (so reconnectErrored picks it up), got %v", cam.GetState())
+	}
+	if cam.GetErrorCount() != 1 {
+		t.Errorf("error count should be 1, got %d", cam.GetErrorCount())
+	}
+	if len(transitions) != 1 || transitions[0] != StateError {
+		t.Errorf("expected 1 Error state-change hook, got %v", transitions)
 	}
 }
 
@@ -239,6 +252,53 @@ func TestManager_SetQuality_NonExistent(t *testing.T) {
 	err := mgr.SetQuality(context.Background(), "nonexistent", "sd")
 	if err != nil {
 		t.Errorf("SetQuality on nonexistent should return nil, got %v", err)
+	}
+}
+
+func TestManager_ReapRenameOrphans(t *testing.T) {
+	// When Wyze user renames "Front Door" → "Front Gate", the next
+	// Discover cycle adds a fresh "front_gate" entry — but the old
+	// "front_door" entry sits forever with its stale go2rtc stream.
+	// reapRenameOrphans matches on MAC and drops the orphan. Issue #100.
+	mgr, go2rtcAPI := newTestManager(t)
+	ctx := context.Background()
+
+	oldCam := NewCamera(wyzeapi.CameraInfo{
+		Name: "front_door", Nickname: "Front Door", MAC: "AABB01", Model: "HL_CAM4",
+	}, "hd", true, false)
+	oldCam.SetState(StateStreaming)
+	mgr.cameras["front_door"] = oldCam
+
+	untouched := NewCamera(wyzeapi.CameraInfo{
+		Name: "backyard", Nickname: "Backyard", MAC: "AABB02", Model: "WYZE_CAKP2JFUS",
+	}, "hd", true, false)
+	untouched.SetState(StateStreaming)
+	mgr.cameras["backyard"] = untouched
+
+	// Pre-register the old go2rtc stream so we can assert it's deleted.
+	if err := go2rtcAPI.AddStream(ctx, "front_door", "wyze://old"); err != nil {
+		t.Fatalf("seed old stream: %v", err)
+	}
+
+	// Discovery now returns the renamed camera + the untouched one.
+	discovered := []wyzeapi.CameraInfo{
+		{Nickname: "Front Gate", MAC: "AABB01", Model: "HL_CAM4"},
+		{Nickname: "Backyard", MAC: "AABB02", Model: "WYZE_CAKP2JFUS"},
+	}
+
+	mgr.mu.Lock()
+	mgr.reapRenameOrphans(ctx, discovered)
+	mgr.mu.Unlock()
+
+	if _, still := mgr.cameras["front_door"]; still {
+		t.Error("front_door orphan should have been reaped")
+	}
+	if _, still := mgr.cameras["backyard"]; !still {
+		t.Error("backyard should NOT have been touched (same name, same MAC)")
+	}
+	streams, _ := go2rtcAPI.ListStreams(ctx)
+	if _, still := streams["front_door"]; still {
+		t.Error("stale go2rtc stream 'front_door' should have been deleted")
 	}
 }
 

--- a/internal/camera/manager.go
+++ b/internal/camera/manager.go
@@ -40,6 +40,9 @@ type Manager struct {
 	onChronicError   func(camName string, errorCount int)
 	onChronicRecover func(camName string)
 	chronicReported  map[string]bool
+	// onProtocolFallback fires the first time a camera is auto-promoted
+	// from TUTK to WebRTC after crossing the fallback threshold.
+	onProtocolFallback func(camName string, oldProtocol, newProtocol string, failStreak int)
 }
 
 // chronicErrorThreshold is the consecutive-error count at which a
@@ -101,6 +104,13 @@ func (m *Manager) OnStateChange(fn StateChangeFunc) {
 func (m *Manager) OnChronicError(onErr func(camName string, errorCount int), onRecover func(camName string)) {
 	m.onChronicError = onErr
 	m.onChronicRecover = onRecover
+}
+
+// OnProtocolFallback registers a callback for a camera being
+// auto-promoted between streaming protocols (currently only
+// TUTK → WebRTC). Fires once per camera per process lifetime.
+func (m *Manager) OnProtocolFallback(fn func(camName string, oldProtocol, newProtocol string, failStreak int)) {
+	m.onProtocolFallback = fn
 }
 
 // Cameras returns a snapshot of all managed cameras, sorted by name
@@ -294,6 +304,7 @@ func (m *Manager) connectCamera(ctx context.Context, cam *Camera) {
 			Int("errors", errors).
 			Msg("failed to add stream to go2rtc")
 		m.maybeReportChronic(cam.Name(), errors)
+		m.recordTUTKFailure(cam, protocol)
 		return
 	}
 
@@ -310,7 +321,7 @@ func (m *Manager) connectCamera(ctx context.Context, cam *Camera) {
 func (m *Manager) streamSourceFor(cam *Camera) (url, protocol string) {
 	info := cam.GetInfo()
 	switch {
-	case info.IsWebRTCStreamer():
+	case cam.ForceWebRTC() || info.IsWebRTCStreamer():
 		return fmt.Sprintf("webrtc:http://127.0.0.1:%d/internal/wyze/webrtc/%s#format=wyze", m.cfg.BridgePort, cam.Name()), "webrtc"
 	case info.IsGwell():
 		return "", "gwell"
@@ -373,6 +384,13 @@ func (m *Manager) HealthCheck(ctx context.Context) {
 				m.onChange(cam, oldState, StateError)
 			}
 			m.maybeReportChronic(cam.Name(), cam.GetErrorCount())
+			// A stream that reached Streaming and then went 0-producers
+			// is a TUTK-path failure signal for HL_CAM4-class regressions
+			// where TUTK dial appears to succeed but the P2P session
+			// never delivers frames. The current-protocol lookup is
+			// per-call (streamSourceFor is idempotent).
+			_, protocol := m.streamSourceFor(cam)
+			m.recordTUTKFailure(cam, protocol)
 		}
 	}
 }
@@ -575,6 +593,51 @@ func (m *Manager) maybeReportChronic(camName string, errorCount int) {
 		return
 	}
 	m.onChronicError(camName, errorCount)
+}
+
+// recordTUTKFailure bumps the camera's TUTK-fail streak and, if the
+// configured threshold is met, flips the camera to the WebRTC path
+// for the rest of the process lifetime. Only counts when we're
+// currently attempting the TUTK protocol — WebRTC / Gwell paths and
+// already-promoted cameras are skipped. Wyze's 2025-02 firmware
+// disabled TUTK on newer HL_CAM4 units without disabling the mars-
+// webcsrv KVS path, so promotion recovers those cameras without
+// operator intervention. See DOCS/TUTK_WEBRTC_FALLBACK_DESIGN.md.
+func (m *Manager) recordTUTKFailure(cam *Camera, protocol string) {
+	if protocol != "tutk" {
+		return
+	}
+	threshold := m.cfg.TUTKFallbackThreshold
+	if threshold <= 0 {
+		return // operator disabled auto-fallback
+	}
+	if cam.ForceWebRTC() {
+		return // already promoted
+	}
+	streak := cam.IncrementTUTKFail()
+	if streak < threshold {
+		return
+	}
+	// Cross-check: only promote if the model can plausibly stream
+	// via WebRTC. The shim will call /v4/camera/get_streams which
+	// only returns a KVS URL for cameras Wyze configured for WebRTC;
+	// blindly flipping a model that doesn't have WebRTC available
+	// would just swap one failure mode for another. We approximate
+	// this by allowing promotion for any camera Wyze exposes MAC +
+	// Model on — the shim's error response is the operator-visible
+	// signal if the coin flip lands wrong.
+	if !cam.SetForceWebRTC(true) {
+		return
+	}
+	cam.ResetTUTKFail()
+	m.log.Warn().
+		Str("cam", cam.Name()).
+		Str("model", cam.GetInfo().Model).
+		Int("streak", streak).
+		Msg("TUTK failing repeatedly, promoting camera to WebRTC")
+	if m.onProtocolFallback != nil {
+		m.onProtocolFallback(cam.Name(), "tutk", "webrtc", streak)
+	}
 }
 
 // clearChronic fires onChronicRecover if the camera was previously

--- a/internal/camera/manager.go
+++ b/internal/camera/manager.go
@@ -197,6 +197,8 @@ func (m *Manager) Discover(ctx context.Context) error {
 		}
 	}
 
+	m.reapRenameOrphans(ctx, filtered)
+
 	// Mark cameras not in discovery as offline
 	for name, cam := range m.cameras {
 		if !seen[name] && cam.GetState() != StateOffline {
@@ -270,6 +272,17 @@ func (m *Manager) connectCamera(ctx context.Context, cam *Camera) {
 		Bool("record", snap.Record).
 		Bool("dtls", snap.Info.DTLS).
 		Msg("connecting camera to go2rtc")
+
+	// Drop any prior go2rtc entry first so the PUT below is a clean
+	// re-create rather than an in-place source swap. Without this,
+	// a reconnect after HealthCheck saw 0 producers can leave the
+	// old (dead) source pool attached and the fresh AddStream never
+	// actually plays. Skipped for Gwell publish-only slots — those
+	// have an active RTSP publisher we'd disrupt (and HealthCheck
+	// already excludes Gwell, so we don't get here for them anyway).
+	if protocol != "gwell" {
+		_ = go2rtc.DeleteStream(ctx, cam.Name())
+	}
 
 	if err := go2rtc.AddStream(ctx, cam.Name(), streamURL); err != nil {
 		backoff := cam.IncrementError()
@@ -346,8 +359,20 @@ func (m *Manager) HealthCheck(ctx context.Context) {
 
 		info, ok := streams[cam.Name()]
 		if !ok || len(info.Producers) == 0 {
-			m.log.Warn().Str("cam", cam.Name()).Msg("stream lost, reconnecting")
-			m.changeState(cam, StateOffline)
+			// Route through StateError with backoff so reconnectErrored's
+			// 10s ticker picks it up. Marking StateOffline used to leave
+			// the camera stuck until the next Discover refresh — reconnect
+			// only handles StateError, not StateOffline.
+			oldState := cam.GetState()
+			backoff := cam.IncrementError()
+			m.log.Warn().
+				Str("cam", cam.Name()).
+				Dur("backoff", backoff).
+				Msg("stream lost, will retry")
+			if m.onChange != nil && oldState != StateError {
+				m.onChange(cam, oldState, StateError)
+			}
+			m.maybeReportChronic(cam.Name(), cam.GetErrorCount())
 		}
 	}
 }
@@ -383,6 +408,41 @@ func (m *Manager) RunDiscoveryLoop(ctx context.Context) {
 		case <-reconnectTicker.C:
 			m.reconnectErrored(ctx)
 		}
+	}
+}
+
+// reapRenameOrphans removes m.cameras entries whose MAC matches a
+// just-discovered camera under a different normalized name (i.e. the
+// user renamed the camera in the Wyze app). Without this, the old
+// entry's go2rtc stream lingers forever — Discover only ever adds
+// new entries, and the old name stays "offline" while a fresh entry
+// is created under the new name. Called under m.mu.Lock() by Discover.
+func (m *Manager) reapRenameOrphans(ctx context.Context, filtered []wyzeapi.CameraInfo) {
+	newByMAC := make(map[string]string, len(filtered))
+	for _, info := range filtered {
+		if info.MAC == "" {
+			continue
+		}
+		newByMAC[info.MAC] = info.NormalizedName()
+	}
+	for oldName, existing := range m.cameras {
+		info := existing.GetInfo()
+		if info.MAC == "" {
+			continue
+		}
+		newName, ok := newByMAC[info.MAC]
+		if !ok || newName == oldName {
+			continue
+		}
+		m.log.Info().
+			Str("old_name", oldName).
+			Str("new_name", newName).
+			Str("mac", info.MAC).
+			Msg("camera rename detected, dropping orphan entry")
+		if go2rtc := m.go2rtcClient(); go2rtc != nil {
+			_ = go2rtc.DeleteStream(ctx, oldName)
+		}
+		delete(m.cameras, oldName)
 	}
 }
 

--- a/internal/camera/tutk_fallback_test.go
+++ b/internal/camera/tutk_fallback_test.go
@@ -1,0 +1,157 @@
+package camera
+
+import (
+	"testing"
+
+	"github.com/IDisposable/docker-wyze-bridge/internal/wyzeapi"
+)
+
+// recordTUTKFailure is the promotion primitive; these tests exercise
+// it in isolation from the connect/health-check plumbing so a broken
+// stream mock can't obscure the state-machine logic. See
+// DOCS/TUTK_WEBRTC_FALLBACK_DESIGN.md.
+
+func newTUTKCam(t *testing.T, name, model string) *Camera {
+	t.Helper()
+	return NewCamera(wyzeapi.CameraInfo{
+		Name:  name,
+		Model: model,
+		MAC:   "AABBCCDD" + name,
+	}, "hd", true, false)
+}
+
+func TestRecordTUTKFailure_PromotesAtThreshold(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mgr.cfg.TUTKFallbackThreshold = 3
+	cam := newTUTKCam(t, "v4", "HL_CAM4")
+	mgr.cameras["v4"] = cam
+
+	var fallbacks []string
+	mgr.OnProtocolFallback(func(camName, oldP, newP string, streak int) {
+		if oldP != "tutk" || newP != "webrtc" || streak != 3 {
+			t.Errorf("callback args: cam=%s old=%s new=%s streak=%d", camName, oldP, newP, streak)
+		}
+		fallbacks = append(fallbacks, camName)
+	})
+
+	for i := 1; i <= 3; i++ {
+		mgr.recordTUTKFailure(cam, "tutk")
+		if i < 3 && cam.ForceWebRTC() {
+			t.Fatalf("promoted early (after %d failures, threshold=3)", i)
+		}
+	}
+	if !cam.ForceWebRTC() {
+		t.Fatal("should have been promoted at threshold=3")
+	}
+	if len(fallbacks) != 1 {
+		t.Errorf("callback should fire exactly once, got %d", len(fallbacks))
+	}
+	// After promotion, streamSourceFor returns the WebRTC URL.
+	u, p := mgr.streamSourceFor(cam)
+	if p != "webrtc" {
+		t.Errorf("post-promotion protocol = %q, want webrtc", p)
+	}
+	if u == "" {
+		t.Error("post-promotion URL should be non-empty (webrtc:… source)")
+	}
+}
+
+func TestRecordTUTKFailure_ResetsOnSuccessfulStreaming(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mgr.cfg.TUTKFallbackThreshold = 5
+	cam := newTUTKCam(t, "v4", "HL_CAM4")
+
+	// 4 failures then a successful Streaming — streak resets.
+	for i := 0; i < 4; i++ {
+		mgr.recordTUTKFailure(cam, "tutk")
+	}
+	if cam.TUTKFailStreak() != 4 {
+		t.Fatalf("streak = %d, want 4 before reset", cam.TUTKFailStreak())
+	}
+	cam.SetState(StateStreaming)
+	if cam.TUTKFailStreak() != 0 {
+		t.Fatalf("streak should reset on Streaming, got %d", cam.TUTKFailStreak())
+	}
+	// Now 4 more failures — should NOT promote (would take a full 5).
+	for i := 0; i < 4; i++ {
+		mgr.recordTUTKFailure(cam, "tutk")
+	}
+	if cam.ForceWebRTC() {
+		t.Error("should not promote — streak reset after streaming means it takes another 5")
+	}
+}
+
+func TestRecordTUTKFailure_IgnoresNonTUTKProtocols(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mgr.cfg.TUTKFallbackThreshold = 2
+
+	// A Gwell camera (Window Cam) — its failure surface is different
+	// (gwell-proxy handshake, not go2rtc TUTK). No promotion.
+	gwell := newTUTKCam(t, "wc", "GW_WC")
+	for i := 0; i < 10; i++ {
+		mgr.recordTUTKFailure(gwell, "gwell")
+	}
+	if gwell.TUTKFailStreak() != 0 || gwell.ForceWebRTC() {
+		t.Errorf("gwell failures shouldn't bump streak or promote — streak=%d forced=%v",
+			gwell.TUTKFailStreak(), gwell.ForceWebRTC())
+	}
+
+	// Already-WebRTC camera — same story.
+	webrtc := newTUTKCam(t, "bell", "GW_BE1")
+	for i := 0; i < 10; i++ {
+		mgr.recordTUTKFailure(webrtc, "webrtc")
+	}
+	if webrtc.TUTKFailStreak() != 0 || webrtc.ForceWebRTC() {
+		t.Errorf("webrtc failures shouldn't bump streak or promote")
+	}
+}
+
+func TestRecordTUTKFailure_ThresholdZeroDisables(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mgr.cfg.TUTKFallbackThreshold = 0
+	cam := newTUTKCam(t, "v4", "HL_CAM4")
+	for i := 0; i < 100; i++ {
+		mgr.recordTUTKFailure(cam, "tutk")
+	}
+	if cam.ForceWebRTC() {
+		t.Error("threshold=0 should disable auto-fallback")
+	}
+	if cam.TUTKFailStreak() != 0 {
+		t.Errorf("streak = %d, want 0 when disabled", cam.TUTKFailStreak())
+	}
+}
+
+func TestRecordTUTKFailure_AlreadyPromotedIsNoOp(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mgr.cfg.TUTKFallbackThreshold = 3
+	cam := newTUTKCam(t, "v4", "HL_CAM4")
+	cam.SetForceWebRTC(true)
+
+	var called int
+	mgr.OnProtocolFallback(func(string, string, string, int) { called++ })
+
+	for i := 0; i < 20; i++ {
+		mgr.recordTUTKFailure(cam, "tutk")
+	}
+	if called != 0 {
+		t.Errorf("fallback callback should not fire when already forced — fired %d times", called)
+	}
+	if cam.TUTKFailStreak() != 0 {
+		t.Errorf("streak should stay 0 on already-promoted camera, got %d", cam.TUTKFailStreak())
+	}
+}
+
+func TestStreamSourceFor_ForceWebRTCOverridesRegistry(t *testing.T) {
+	mgr, _ := newTestManager(t)
+
+	// Baseline: HL_CAM4 defaults to TUTK.
+	cam := newTUTKCam(t, "v4", "HL_CAM4")
+	if _, p := mgr.streamSourceFor(cam); p != "tutk" {
+		t.Fatalf("HL_CAM4 baseline protocol = %q, want tutk", p)
+	}
+	// Force flag flips the routing decision.
+	cam.SetForceWebRTC(true)
+	if u, p := mgr.streamSourceFor(cam); p != "webrtc" || u == "" {
+		t.Errorf("post-force protocol = %q url = %q, want (webrtc, non-empty)", p, u)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,14 @@ type Config struct {
 	Audio       bool
 	OfflineTime int
 
+	// TUTKFallbackThreshold is the consecutive-TUTK-failure count at
+	// which a camera is auto-promoted to the WebRTC path. Motivated
+	// by Wyze's 2025-02 firmware disabling TUTK on newer HL_CAM4
+	// units. Zero disables the auto-fallback (operators fall back to
+	// the manual MODEL_OVERRIDES workaround). See
+	// DOCS/TUTK_WEBRTC_FALLBACK_DESIGN.md.
+	TUTKFallbackThreshold int
+
 	// Recording
 	RecordAll      bool
 	RecordPath     string
@@ -166,9 +174,10 @@ func Load() (*Config, error) {
 		FilterBlocks: envBool("FILTER_BLOCKS", false),
 
 		// Camera Defaults
-		Quality:     env("QUALITY", "hd"),
-		Audio:       envBool("AUDIO", true),
-		OfflineTime: envInt("OFFLINE_TIME", 30),
+		Quality:               env("QUALITY", "hd"),
+		Audio:                 envBool("AUDIO", true),
+		OfflineTime:           envInt("OFFLINE_TIME", 30),
+		TUTKFallbackThreshold: envInt("TUTK_FALLBACK_THRESHOLD", 5),
 
 		// Recording — default under /media/recordings so bare-Docker
 		// users can mount a single host directory at /media and get

--- a/internal/webui/api_actions_test.go
+++ b/internal/webui/api_actions_test.go
@@ -275,3 +275,29 @@ func TestHandleShimKVSSignaling_NonWebRTCCameraRejected(t *testing.T) {
 		t.Errorf("status = %d, want 404 for non-WebRTC camera", w.Code)
 	}
 }
+
+func TestHandleShimKVSSignaling_ForceWebRTCPassesGate(t *testing.T) {
+	// The runtime TUTK→WebRTC auto-fallback flips a per-Camera flag
+	// without changing the model registry. The shim must honor it so
+	// a promoted HL_CAM4 (or any other TUTK-default model) can
+	// actually mint a KVS signaling URL.
+	srv, _ := testServer(t)
+	cam := camera.NewCamera(wyzeapi.CameraInfo{
+		Name: "front_door", Model: "HL_CAM4", MAC: "AABB",
+	}, "hd", true, false)
+	cam.SetForceWebRTC(true)
+	srv.camMgr.InjectCamera("front_door", cam)
+	srv.kvs = &fakeKVSProvider{
+		signalingURL: "wss://wyze-mars-webcsrv.wyzecam.com?token=forced",
+		ice:          []KVSIceServer{{URL: "stun:stun.example.com:443"}},
+	}
+
+	req := httptest.NewRequest("GET", "/internal/wyze/webrtc/front_door", nil)
+	req.RemoteAddr = "127.0.0.1:54321"
+	w := httptest.NewRecorder()
+	srv.handleShimKVSSignaling(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s; force-promoted camera should reach KVS", w.Code, w.Body.String())
+	}
+}

--- a/internal/webui/metrics.go
+++ b/internal/webui/metrics.go
@@ -32,17 +32,22 @@ type BridgeSummary struct {
 }
 
 type CameraMetric struct {
-	Name         string `json:"name"`
-	Nickname     string `json:"nickname"`
-	Model        string `json:"model"`
-	ModelName    string `json:"model_name"`
-	Protocol     string `json:"protocol"` // "tutk" | "gwell" | "webrtc"
-	State        string `json:"state"`
-	Quality      string `json:"quality"`
-	AudioOn      bool   `json:"audio"`
-	ErrorCount   int    `json:"error_count"`
-	Recording    bool   `json:"recording"`
-	SessionBytes int64  `json:"session_bytes,omitempty"`
+	Name      string `json:"name"`
+	Nickname  string `json:"nickname"`
+	Model     string `json:"model"`
+	ModelName string `json:"model_name"`
+	Protocol  string `json:"protocol"` // "tutk" | "gwell" | "webrtc"
+	// ProtocolForced is true when the current Protocol reflects a
+	// runtime TUTK→WebRTC auto-fallback rather than the model
+	// registry's default. Lets operators tell "Wyze pushed a bad FW"
+	// from "we always ran it this way." Omitted from JSON when false.
+	ProtocolForced bool   `json:"protocol_forced,omitempty"`
+	State          string `json:"state"`
+	Quality        string `json:"quality"`
+	AudioOn        bool   `json:"audio"`
+	ErrorCount     int    `json:"error_count"`
+	Recording      bool   `json:"recording"`
+	SessionBytes   int64  `json:"session_bytes,omitempty"`
 }
 
 type StorageSummary struct {
@@ -109,15 +114,16 @@ func (s *Server) buildMetricsSnapshot() MetricsSnapshot {
 			snap.Bridge.ErrorCount++
 		}
 		cm := CameraMetric{
-			Name:       cam.Name(),
-			Nickname:   cs.Info.Nickname,
-			Model:      cs.Info.Model,
-			ModelName:  cs.Info.ModelName(),
-			Protocol:   protocolFor(cs.Info),
-			State:      state,
-			Quality:    cs.Quality,
-			AudioOn:    cs.AudioOn,
-			ErrorCount: cs.ErrorCount,
+			Name:           cam.Name(),
+			Nickname:       cs.Info.Nickname,
+			Model:          cs.Info.Model,
+			ModelName:      cs.Info.ModelName(),
+			Protocol:       protocolFor(cs.Info, cs.ForceWebRTC),
+			ProtocolForced: cs.ForceWebRTC,
+			State:          state,
+			Quality:        cs.Quality,
+			AudioOn:        cs.AudioOn,
+			ErrorCount:     cs.ErrorCount,
 		}
 		if s.recMgr != nil {
 			cm.Recording = s.recMgr.IsRecording(cam.Name())
@@ -147,10 +153,11 @@ func (s *Server) buildMetricsSnapshot() MetricsSnapshot {
 
 // protocolFor matches camera.Manager.streamSourceFor's logic without
 // importing camera (it already imports wyzeapi). Keeps the view layer
-// from having to know the streamSourceFor contract.
-func protocolFor(info wyzeapi.CameraInfo) string {
+// from having to know the streamSourceFor contract. forceWebRTC
+// reflects the per-camera runtime auto-fallback state.
+func protocolFor(info wyzeapi.CameraInfo, forceWebRTC bool) string {
 	switch {
-	case info.IsWebRTCStreamer():
+	case forceWebRTC || info.IsWebRTCStreamer():
 		return "webrtc"
 	case info.IsGwell():
 		return "gwell"
@@ -299,7 +306,7 @@ const metricsHTML = `<!DOCTYPE html>
   <tr>
     <td><a href="{{$.BasePath}}/camera/{{.Name}}">{{.Nickname}}</a><br><code class="muted">{{.Name}}</code></td>
     <td>{{.ModelName}}<br><code class="muted">{{.Model}}</code></td>
-    <td>{{.Protocol}}</td>
+    <td>{{.Protocol}}{{if .ProtocolForced}} <span class="muted" title="Auto-promoted from TUTK after repeated failures — see /api/health for details">(forced)</span>{{end}}</td>
     <td><span class="pill state-{{.State}}">{{.State}}</span></td>
     <td>{{.Quality}}</td>
     <td>{{if .AudioOn}}✓{{else}}✗{{end}}</td>

--- a/internal/webui/shim_kvs.go
+++ b/internal/webui/shim_kvs.go
@@ -56,7 +56,10 @@ func (s *Server) handleShimKVSSignaling(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	info := cam.GetInfo()
-	if !info.IsWebRTCStreamer() {
+	// Camera.ForceWebRTC lets the manager promote a runtime-flipped
+	// camera (see TUTK→WebRTC auto-fallback) even when the registry
+	// still marks the model as TUTK-only.
+	if !info.IsWebRTCStreamer() && !cam.ForceWebRTC() {
 		http.Error(w, "camera does not use WebRTC streaming", http.StatusNotFound)
 		return
 	}

--- a/internal/webui/static/video-stream.js
+++ b/internal/webui/static/video-stream.js
@@ -3,6 +3,12 @@
 // it does NOT observe the `src` HTML attribute, so `<video-rtc src="...">`
 // in HTML never triggers the setter. The subclass below observes it and
 // forwards attribute changes to the setter so the element connects on mount.
+//
+// The `muted` attribute is also honored: video-rtc.js only mutes on
+// autoplay failure, so once the browser grants an origin autoplay
+// permission (after any user click), grid videos start unmuted on the
+// next page load. Reading `muted` in oninit and applying it to the
+// internal <video> keeps the grid quiet regardless of engagement state.
 import { VideoRTC } from './video-rtc.js';
 
 if (!customElements.get('video-rtc')) {
@@ -11,6 +17,12 @@ if (!customElements.get('video-rtc')) {
         attributeChangedCallback(name, oldValue, newValue) {
             if (name === 'src' && newValue && newValue !== oldValue) {
                 this.src = newValue;
+            }
+        }
+        oninit() {
+            super.oninit();
+            if (this.hasAttribute('muted')) {
+                this.video.muted = true;
             }
         }
     });

--- a/internal/webui/templates.go
+++ b/internal/webui/templates.go
@@ -171,7 +171,7 @@ const indexHTML = `<!DOCTYPE html>
             <div class="camera-card" data-cam="{{.Name}}" data-state="{{.State}}">
                 <div class="camera-preview">
                     {{if eq .State "streaming"}}
-                    <video-rtc src="{{.Go2RTCURL}}" data-poster="{{.SnapshotURL}}"></video-rtc>
+                    <video-rtc src="{{.Go2RTCURL}}" data-poster="{{.SnapshotURL}}" muted></video-rtc>
                     {{else}}
                     <img src="{{.SnapshotURL}}" alt="{{.Nickname}}" loading="lazy"
                          onerror="this.style.display='none'">


### PR DESCRIPTION
## What's in v4.5.0

Runtime **TUTK → WebRTC auto-fallback** for Wyze cameras crippled by
firmware updates (primarily V4/`HL_CAM4`). Plus the 4.4.2 reliability
bundle folded in.

### Feature (4.5.0)
- Per-camera auto-promotion from TUTK to WebRTC after
  `TUTK_FALLBACK_THRESHOLD` (default 5) consecutive failures.
- `/api/metrics` exposes `protocol_forced`; metrics page shows
  `webrtc (forced)`.
- Issues registry entry `camera/fallback/<name>` on promotion.
- Manual `MODEL_OVERRIDES=HL_CAM4:is_webrtc=true` still takes
  precedence.
- Design + tests: `DOCS/TUTK_WEBRTC_FALLBACK_DESIGN.md`.

### Reliability (folded from unreleased 4.4.2)
- Stream auto-recovery (#100) — HealthCheck actually reconnects
  now; connectCamera clears stale go2rtc entries; rename orphans
  are reaped by MAC.
- Grid audio stays muted (#112) — `<video-rtc muted>` honored
  proactively.
- Doc updates (#99) — MIGRATION → Camera Names calls out Frigate/
  HA/Lovelace/Node-RED surfaces.

Closes #72, #100, #112, #117, #92, #87, #99